### PR TITLE
Provide better error logging for debugging

### DIFF
--- a/lib/ansible_tower_client/api.rb
+++ b/lib/ansible_tower_client/api.rb
@@ -65,8 +65,11 @@ module AnsibleTowerClient
     rescue Faraday::ConnectionFailed, Faraday::SSLError => err
       raise
     rescue Faraday::ClientError => err
-      message = JSON.parse(err.message)['detail'] rescue nil
+      response = err.response
+      logger.debug { "#{self.class.name} #{err.class.name} #{response.pretty_inspect}" }
+      message   = JSON.parse(response[:body])['detail'] rescue nil
       message ||= "An unknown error was returned from the provider"
+      logger.error("#{self.class.name} #{err.class.name} #{message}")
       raise AnsibleTowerClient::ConnectionError, message
     end
 


### PR DESCRIPTION
GET missing resource
```
[----] E, [2016-12-02T15:25:56.560087 #2118:100f108] ERROR -- : AnsibleTowerClient::Api Faraday::ResourceNotFound Not found.
```

With debug logging:
```
[----] D, [2016-12-02T15:26:13.107248 #2118:100f108] DEBUG -- : AnsibleTowerClient::Api Sending <get> with <["job_templates/1111111/"]>
[----] D, [2016-12-02T15:26:13.344309 #2118:100f108] DEBUG -- : AnsibleTowerClient::Api Faraday::ResourceNotFound {:status=>404,
 :headers=>
  {"date"=>"Fri, 02 Dec 2016 21:25:46 GMT",
   "server"=>
    "Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5",
   "vary"=>"Accept,Cookie",
   "allow"=>"GET, PUT, PATCH, DELETE, HEAD, OPTIONS",
   "x-api-time"=>"0.031s",
   "content-length"=>"23",
   "connection"=>"close",
   "content-type"=>"application/json"},
 :body=>"{\"detail\":\"Not found.\"}"}

[----] E, [2016-12-02T15:26:13.344536 #2118:100f108] ERROR -- : AnsibleTowerClient::Api Faraday::ResourceNotFound Not found.
```

https://bugzilla.redhat.com/show_bug.cgi?id=1393941