### PR TITLE
Add create method to the base_model

### DIFF
--- a/lib/ansible_tower_client/base_model.rb
+++ b/lib/ansible_tower_client/base_model.rb
@@ -37,6 +37,11 @@ module AnsibleTowerClient
       super(raw_hash)
     end
 
+    def self.create(api, attributes)
+      response = api.post("#{endpoint}/", attributes).body
+      new(api, JSON.parse(response))
+    end
+
     def hashify(attribute)
       YAML.safe_load(send(attribute))
     end

--- a/spec/ad_hoc_command_spec.rb
+++ b/spec/ad_hoc_command_spec.rb
@@ -7,6 +7,7 @@ describe AnsibleTowerClient::AdHocCommand do
   let(:raw_instance)        { build(:response_instance, :klass => described_class) }
 
   include_examples "Collection Methods"
+  include_examples "Crud Methods"
 
   it "#initialize instantiates an #{described_class} from a hash" do
     obj = described_class.new(instance_double("AnsibleTowerClient::Api"), raw_instance)

--- a/spec/group_spec.rb
+++ b/spec/group_spec.rb
@@ -7,6 +7,7 @@ describe AnsibleTowerClient::Group do
   let(:raw_instance)        { build(:response_instance, :group, :klass => described_class) }
 
   include_examples "Collection Methods"
+  include_examples "Crud Methods"
 
   it "#initialize instantiates an #{described_class} from a hash" do
     obj = described_class.new(instance_double("AnsibleTowerClient::Api"), raw_instance)

--- a/spec/host_spec.rb
+++ b/spec/host_spec.rb
@@ -9,6 +9,7 @@ describe AnsibleTowerClient::Host do
   let(:raw_instance)        { build(:response_instance, :host, :klass => described_class) }
 
   include_examples "Collection Methods"
+  include_examples "Crud Methods"
 
   it "#initialize instantiates an #{described_class} from a hash" do
     obj = described_class.new(instance_double("AnsibleTowerClient::Api"), raw_instance)

--- a/spec/inventory_source_spec.rb
+++ b/spec/inventory_source_spec.rb
@@ -7,6 +7,7 @@ describe AnsibleTowerClient::InventorySource do
   let(:raw_instance)        { build(:response_instance, :klass => described_class) }
 
   include_examples "Collection Methods"
+  include_examples "Crud Methods"
 
   it "#initialize instantiates an #{described_class} from a hash" do
     obj = described_class.new(instance_double("AnsibleTowerClient::Api"), raw_instance)

--- a/spec/inventory_spec.rb
+++ b/spec/inventory_spec.rb
@@ -8,6 +8,7 @@ describe AnsibleTowerClient::Inventory do
   let(:raw_instance)        { build(:response_instance, :klass => described_class) }
 
   include_examples "Collection Methods"
+  include_examples "Crud Methods"
 
   it "#initialize instantiates an #{described_class} from a hash" do
     obj = described_class.new(instance_double("AnsibleTowerClient::Api"), raw_instance)

--- a/spec/job_spec.rb
+++ b/spec/job_spec.rb
@@ -9,6 +9,7 @@ describe AnsibleTowerClient::Job do
   let(:raw_instance_no_output)     { build(:response_instance, :job_template, :klass => described_class, :related => {}) }
 
   include_examples "Collection Methods"
+  include_examples "Crud Methods"
 
   it "#initialize instantiates an #{described_class} from a hash" do
     obj = described_class.new(instance_double("AnsibleTowerClient::Api"), raw_instance)

--- a/spec/job_template_spec.rb
+++ b/spec/job_template_spec.rb
@@ -13,6 +13,7 @@ describe AnsibleTowerClient::JobTemplate do
   let(:raw_instance_no_survey)     { build(:response_instance, :job_template, :klass => described_class, :related => {}) }
 
   include_examples "Collection Methods"
+  include_examples "Crud Methods"
   include_examples "JobTemplate#initialize"
   include_examples "JobTemplate#survey_spec"
   include_examples "JobTemplate#survey_spec_hash"

--- a/spec/job_template_v2_spec.rb
+++ b/spec/job_template_v2_spec.rb
@@ -13,6 +13,7 @@ describe AnsibleTowerClient::JobTemplateV2 do
   let(:raw_instance_no_survey)     { build(:response_instance, :job_template, :klass => described_class.base_class, :related => {}) }
 
   include_examples "Collection Methods"
+  include_examples "Crud Methods"
   include_examples "JobTemplate#initialize"
   include_examples "JobTemplate#survey_spec"
   include_examples "JobTemplate#survey_spec_hash"

--- a/spec/support/shared_examples/crud_methods.rb
+++ b/spec/support/shared_examples/crud_methods.rb
@@ -1,0 +1,6 @@
+shared_examples_for "Crud Methods" do
+  it ".create posts to the api and returns the new instance" do
+    expect(api).to receive(:post).and_return(instance_double("Faraday::Result", :body => raw_instance.to_json))
+    expect(described_class.create(api, {:name => 'test'}.to_json)).to be_a described_class
+  end
+end


### PR DESCRIPTION
Opens create to all subclasses
The InventorySource class does not support POST's per the API
Overriding the self.create method to save the lookup