### PR TITLE
Added update and delete to the base_model

### DIFF
--- a/lib/ansible_tower_client/base_model.rb
+++ b/lib/ansible_tower_client/base_model.rb
@@ -42,6 +42,19 @@ module AnsibleTowerClient
       new(api, JSON.parse(response))
     end
 
+    def update(attributes)
+      @api.patch(url, attributes.to_json)
+      attributes.each do |method_name, value|
+        self.send("#{method_name}=",value)
+      end
+      self
+    end
+
+    def delete
+      @api.delete(url)
+      self
+    end
+
     def hashify(attribute)
       YAML.safe_load(send(attribute))
     end
@@ -78,7 +91,7 @@ module AnsibleTowerClient
       end
 
       def generate_writer?
-        false
+        true
       end
     end
   end

--- a/spec/inventory_source_spec.rb
+++ b/spec/inventory_source_spec.rb
@@ -7,7 +7,6 @@ describe AnsibleTowerClient::InventorySource do
   let(:raw_instance)        { build(:response_instance, :klass => described_class) }
 
   include_examples "Collection Methods"
-  include_examples "Crud Methods"
 
   it "#initialize instantiates an #{described_class} from a hash" do
     obj = described_class.new(instance_double("AnsibleTowerClient::Api"), raw_instance)
@@ -29,6 +28,13 @@ describe AnsibleTowerClient::InventorySource do
     it 'returns false' do
       expect(api).to receive(:get).and_return(instance_double("Faraday::Response", :body => can_update_false.to_json))
       expect(described_class.new(api, raw_instance).can_update?).to be_falsey
+    end
+  end
+
+  describe 'create' do
+    it "described_class.create posts to the api and returns the new instance" do
+      expect(api).to receive(:post).and_return(instance_double("Faraday::Result", :body => raw_instance.to_json))
+      expect(described_class.create(api, {:name => 'test'}.to_json)).to be_a described_class
     end
   end
 

--- a/spec/support/shared_examples/crud_methods.rb
+++ b/spec/support/shared_examples/crud_methods.rb
@@ -1,6 +1,18 @@
 shared_examples_for "Crud Methods" do
-  it ".create posts to the api and returns the new instance" do
+  it "described_class.create posts to the api and returns the new instance" do
     expect(api).to receive(:post).and_return(instance_double("Faraday::Result", :body => raw_instance.to_json))
     expect(described_class.create(api, {:name => 'test'}.to_json)).to be_a described_class
+  end
+
+  it ".update patches an object and returns the updated instance" do
+    expect(api).to receive(:patch)
+    klass_instance = described_class.new(api, raw_instance).update({:name => 'test'})
+    expect(klass_instance.name).to eq 'test'
+  end
+
+  it ".delete deletes an object and returns the original object" do
+    expect(api).to receive(:delete)
+    klass_instance = described_class.new(api, raw_instance)
+    expect(klass_instance.delete).to eq klass_instance
   end
 end


### PR DESCRIPTION
`update`: updates the current instance and applies the updated attributes to the caller.
`generate_writer?` was enabled for all subclasses to allow the caller to be updated.

`delete`: deletes the record and returns a copy of the original record.