### PR TITLE
allow passing of GET options to .all in collections

### DIFF
--- a/lib/ansible_tower_client/collection.rb
+++ b/lib/ansible_tower_client/collection.rb
@@ -6,6 +6,8 @@ module AnsibleTowerClient
       @klass = klass
     end
 
+    # @param get_options [Hash] a hash of http GET params to pass to the api request
+    #   e.g. { :order_by => 'timestamp', :name__contains => 'foo' }
     def all(get_options = nil)
       find_all_by_url(klass.endpoint, get_options)
     end

--- a/lib/ansible_tower_client/collection.rb
+++ b/lib/ansible_tower_client/collection.rb
@@ -6,17 +6,18 @@ module AnsibleTowerClient
       @klass = klass
     end
 
-    def all
-      find_all_by_url(klass.endpoint)
+    def all(get_options = nil)
+      find_all_by_url(klass.endpoint, get_options)
     end
 
-    def find_all_by_url(url)
+    def find_all_by_url(url, get_options = nil)
       Enumerator.new do |yielder|
         @collection = []
         next_page   = url
 
         loop do
-          next_page = fetch_more_results(next_page) if @collection.empty?
+          next_page = fetch_more_results(next_page, get_options) if @collection.empty?
+          get_options = nil
           raise StopIteration if @collection.empty?
           yielder.yield(@collection.shift)
         end
@@ -33,9 +34,9 @@ module AnsibleTowerClient
       api.send("#{type}_class")
     end
 
-    def fetch_more_results(next_page)
+    def fetch_more_results(next_page, get_options)
       return if next_page.nil?
-      body = parse_response(api.get(next_page))
+      body = parse_response(api.get(next_page, get_options))
       parse_result_set(body["results"])
 
       body["next"]

--- a/spec/support/shared_examples/collection_methods.rb
+++ b/spec/support/shared_examples/collection_methods.rb
@@ -1,6 +1,6 @@
 shared_examples_for "Collection Methods" do
   it ".all returns an enumerator that will delay load a collection" do
-    expect(collection).to receive(:find_all_by_url).with(described_class.endpoint)
+    expect(collection).to receive(:find_all_by_url).with(described_class.endpoint, any_args)
 
     collection.all
   end


### PR DESCRIPTION
adds ability to pass down options to collections

```ruby
filter = {
 :order_by      => 'timestamp',
 :timestamp__gt => '2016-08-02T17:56:37.212874Z'
}
connection.api.activity_stream.all(filter)
```

see sorting, searching and filtering in the tower api docs https://docs.ansible.com/ansible-tower/3.0.1/html/towerapi

@miq-bot assign @syncrou 
