### PR TITLE
Allow for development Gemfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /.bundle/
 /.yardoc
 /Gemfile.lock
+/Gemfile.dev.rb
 /_yardoc/
 /coverage/
 /doc/

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,9 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in ansible_tower_client.gemspec
 gemspec
 
+# Pull in a development Gemfile if one exists
+eval_gemfile('Gemfile.dev.rb') if File.exists?('Gemfile.dev.rb')
+
 # HACK: Rails 5 dropped support for Ruby < 2.2.2
 active_support_version = "< 5" if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.2.2")
 gem "activesupport", active_support_version

--- a/ansible_tower_client.gemspec
+++ b/ansible_tower_client.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "more_core_extensions", "~> 3.0"
 
   spec.add_development_dependency "bundler", "~> 1.10"
-  spec.add_development_dependency "byebug"
   spec.add_development_dependency "factory_girl"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec"


### PR DESCRIPTION
If there is a development Gemfile called Gemfile.dev.rb
bundler will pull it in and include those gems
as development dependencies.