### PR TITLE
Add create to collection

### DIFF
--- a/lib/ansible_tower_client/base_model.rb
+++ b/lib/ansible_tower_client/base_model.rb
@@ -37,9 +37,15 @@ module AnsibleTowerClient
       super(raw_hash)
     end
 
-    def self.create(api, attributes)
+    def self.create!(api, attributes)
       response = api.post("#{endpoint}/", attributes).body
       new(api, JSON.parse(response))
+    end
+
+    def self.create(*args)
+      create!(*args)
+    rescue AnsibleTowerClient::Error # Any Errors from the API should already be logged
+      false
     end
 
     def hashify(attribute)

--- a/lib/ansible_tower_client/collection.rb
+++ b/lib/ansible_tower_client/collection.rb
@@ -30,6 +30,14 @@ module AnsibleTowerClient
       build_object(parse_response(api.get("#{klass.endpoint}/#{id}/")))
     end
 
+    def create!(*args)
+      klass.create!(api, *args)
+    end
+
+    def create(*args)
+      klass.create(api, *args)
+    end
+
     private
 
     def class_from_type(type)

--- a/lib/ansible_tower_client/exception.rb
+++ b/lib/ansible_tower_client/exception.rb
@@ -1,3 +1,4 @@
 module AnsibleTowerClient
-  class ConnectionError < Exception; end
+  class Error < Exception; end
+  class ConnectionError < Error; end
 end


### PR DESCRIPTION
- Be more like ActiveRecord::Base
- Allow `create` to be called on an instance of AnsibleTowerClient::Collection