### PR TITLE
Expose playbooks off of projects

### DIFF
--- a/lib/ansible_tower_client/base_models/project.rb
+++ b/lib/ansible_tower_client/base_models/project.rb
@@ -3,5 +3,9 @@ module AnsibleTowerClient
     def self.endpoint
       "projects".freeze
     end
+
+    def playbooks
+      Collection.new(api).find_all_by_url(related['playbooks'])
+    end
   end
 end

--- a/lib/ansible_tower_client/collection.rb
+++ b/lib/ansible_tower_client/collection.rb
@@ -57,7 +57,7 @@ module AnsibleTowerClient
     def parse_result_set(body)
       case body.class.name
       when "Array" then
-        body.each { |result| @collection << result }
+        @collection = body
         nil
       when "Hash" then
         body["results"].each { |result| @collection << build_object(result) }

--- a/lib/ansible_tower_client/collection.rb
+++ b/lib/ansible_tower_client/collection.rb
@@ -47,17 +47,22 @@ module AnsibleTowerClient
     def fetch_more_results(next_page, get_options)
       return if next_page.nil?
       body = parse_response(api.get(next_page, get_options))
-      parse_result_set(body["results"])
-
-      body["next"]
+      parse_result_set(body)
     end
 
     def parse_response(response)
       JSON.parse(response.body)
     end
 
-    def parse_result_set(results)
-      results.each { |result| @collection << build_object(result) }
+    def parse_result_set(body)
+      case body.class.name
+      when "Array" then
+        body.each { |result| @collection << result }
+        nil
+      when "Hash" then
+        body["results"].each { |result| @collection << build_object(result) }
+        body["next"]
+      end
     end
 
     def build_object(result)

--- a/spec/support/shared_examples/collection_methods.rb
+++ b/spec/support/shared_examples/collection_methods.rb
@@ -18,6 +18,20 @@ shared_examples_for "Collection Methods" do
     expect(obj_collection_array.first.url).to eq(url)
   end
 
+  it ".find_all_by_url returns a collection of items via a url" do
+    raw_collection_array = raw_url_collection.to_a.flatten
+    expect(api).to receive(:get).and_return(instance_double("Faraday::Result", :body => raw_collection_array.to_json))
+    url = raw_url_collection['url']
+
+    obj_collection = collection.find_all_by_url(url)
+    expect(obj_collection).to be_a Enumerator
+
+    obj_collection_array = obj_collection.to_a
+    expect(obj_collection_array.length).to    eq(8)
+    expect(obj_collection_array.first).to_not eq described_class
+    expect(obj_collection_array.first).to be_a String
+  end
+
   it ".find returns an instance" do
     expect(api).to receive(:get).and_return(instance_double("Faraday::Result", :body => raw_instance.to_json))
 


### PR DESCRIPTION
Playbooks are only available from a project.
This PR exposes `/playbooks` as a collection from said project.

The Tower API returns playbooks as an Array vs a Hash from POST, PUT, PATCH(able) endpoints.
The `parse_result_set` method was modified to handle each case appropriately while not breaking the existing lazy `Enumerator` behavior.

https://www.pivotaltracker.com/story/show/137293767

> Testing Notes

```
conn = AnsibleTowerClient::Connection.new(
  :username => "username",
  :password => "password",
  :base_url => "https://dev-ansible-tower3.test.com/api/v1",
  :verify_ssl => OpenSSL::SSL::VERIFY_NONE
)
proj = conn.api.projects.find <id>
proj.playbooks.first
```

```
conn = AnsibleTowerClient::Connection.new(
  :username => "username",
  :password => "password",
  :base_url => "https://dev-ansible-tower3.test.com/api/v1",
  :verify_ssl => OpenSSL::SSL::VERIFY_NONE
)
proj = conn.api.projects.find <id>
proj.playbooks.each { |x| puts x }
```
