### PR TITLE
Expose credential off of JobTemplate

### DIFF
--- a/lib/ansible_tower_client/base_models/job_template.rb
+++ b/lib/ansible_tower_client/base_models/job_template.rb
@@ -7,6 +7,12 @@ module AnsibleTowerClient
       api.jobs.find(job['job'])
     end
 
+    def credential
+      cred_id = to_hash['credential']
+      return nil unless cred_id
+      api.credentials.find(cred_id)
+    end
+
     def survey_spec
       spec_url = related['survey_spec']
       return nil unless spec_url

--- a/spec/factories/responses.rb
+++ b/spec/factories/responses.rb
@@ -24,10 +24,11 @@ FactoryGirl.define do
     sequence(:id)
     klass      ""
     type       { AnsibleTowerClient::FactoryHelper.underscore_string(klass.namespace.last) }
-    name       { "#{type}-#{id}" }
-    url        { "/api/v1/#{klass.endpoint}/#{id}/" }
-    related    { {"survey_spec" => "example.com/api", 'inventory' => 'inventory link', 'stdout' => 'example.com/api'} }
+    credential { "" }
     limit      { "" }
+    name       { "#{type}-#{id}" }
+    related    { {"survey_spec" => "example.com/api", 'inventory' => 'inventory link', 'stdout' => 'example.com/api'} }
+    url        { "/api/v1/#{klass.endpoint}/#{id}/" }
 
     trait(:description)  { sequence(:description) { |n| "description_#{n}" } }
     trait(:extra_vars)   { extra_vars { {:option => "lots of options"}.to_json } }

--- a/spec/job_template_spec.rb
+++ b/spec/job_template_spec.rb
@@ -6,9 +6,11 @@ describe AnsibleTowerClient::JobTemplate do
   let(:collection)          { api.job_templates }
   let(:connection)          { instance_double("Faraday::Connection") }
   let(:config)              { {"version" => "1.1"} }
+  let(:credential)          { build(:response_instance, :credential, :klass => AnsibleTowerClient::Credential) }
   let(:raw_collection)      { build(:response_collection, :klass => described_class) }
   let(:raw_url_collection)  { build(:response_url_collection, :klass => described_class, :url => url) }
   let(:raw_instance)        { build(:response_instance, :job_template, :klass => described_class) }
+  let(:raw_instance_credential)    { build(:response_instance, :job_template, :klass => described_class, :credential => 1) }
   let(:raw_instance_no_extra_vars) { build(:response_instance, :job_template, :klass => described_class, :extra_vars => '') }
   let(:raw_instance_no_survey)     { build(:response_instance, :job_template, :klass => described_class, :related => {}) }
 
@@ -19,6 +21,17 @@ describe AnsibleTowerClient::JobTemplate do
   include_examples "JobTemplate#survey_spec"
   include_examples "JobTemplate#survey_spec_hash"
   include_examples "JobTemplate#extra_vars_hash"
+
+  describe '#credential' do
+    let(:post_result_body) { {:credential => 1} }
+
+    it "returns a credential object" do
+      expect_any_instance_of(AnsibleTowerClient::Collection).to receive(:find).with(post_result_body[:credential])
+        .and_return(credential)
+      credential = described_class.new(api, raw_instance_credential).credential
+      expect(credential['kind']).to eq 'machine'
+    end
+  end
 
   describe '#launch' do
     let(:json) { {'extra_vars' => "{\"instance_ids\":[\"i-999c\"],\"state\":\"absent\",\"subnet_id\":\"subnet-887\"}"} }

--- a/spec/support/factory_helper.rb
+++ b/spec/support/factory_helper.rb
@@ -2,7 +2,7 @@ require 'securerandom'
 
 module AnsibleTowerClient
   module FactoryHelper
-    KEYS = [:description, :extra_vars, :id, :instance_id, :inventory,
+    KEYS = [:credential, :description, :extra_vars, :id, :instance_id, :inventory,
             :kind, :name, :organization, :related, :results, :type, :url, :username].freeze
     def self.stringify_attribute_keys(hash)
       KEYS.each do |attribute|


### PR DESCRIPTION
The credential attribute was simply returning the id vs
running a lookup and grabbing the AnsibleTowerClient::Credential object