### PR TITLE
All client errors should derive from AnsibleTowerClient::ClientError

### DIFF
--- a/lib/ansible_tower_client/api.rb
+++ b/lib/ansible_tower_client/api.rb
@@ -78,8 +78,10 @@ module AnsibleTowerClient
       else
         super
       end
-    rescue Faraday::ConnectionFailed, Faraday::SSLError => err
-      raise
+    rescue Faraday::ConnectionFailed => err
+      raise AnsibleTowerClient::ConnectionError, err
+    rescue Faraday::SSLError => err
+      raise AnsibleTowerClient::SSLError, err
     rescue Faraday::ClientError => err
       raise if err.response.nil?
       response = err.response

--- a/lib/ansible_tower_client/exception.rb
+++ b/lib/ansible_tower_client/exception.rb
@@ -1,7 +1,10 @@
 module AnsibleTowerClient
-  class Error < Exception; end
-  class ClientError < Error; end
-  class ConnectionError < Error; end
+  class Error         < Exception; end
+  class ClientError   < Error; end
   class NoMethodError < Error; end
-  class UnlicensedFeatureError < Error; end
+
+  class ConnectionError        < ClientError; end
+  class ResourceNotFoundError  < ClientError; end
+  class SSLError               < ClientError; end
+  class UnlicensedFeatureError < ClientError; end
 end

--- a/lib/ansible_tower_client/middleware/raise_tower_error.rb
+++ b/lib/ansible_tower_client/middleware/raise_tower_error.rb
@@ -8,10 +8,10 @@ module AnsibleTowerClient
         when 402
           raise AnsibleTowerClient::UnlicensedFeatureError
         when 404
-          raise Faraday::Error::ResourceNotFound, response_values(env)
+          raise AnsibleTowerClient::ResourceNotFoundError, response_values(env)
         when 407
           # mimic the behavior that we get with proxy requests with HTTPS
-          raise Faraday::Error::ConnectionFailed, %(407 "Proxy Authentication Required ")
+          raise AnsibleTowerClient::ConnectionError, %(407 "Proxy Authentication Required ")
         when CLIENT_ERROR_STATUSES
           raise AnsibleTowerClient::ClientError, env.body
         end

--- a/spec/middleware/raise_tower_error_spec.rb
+++ b/spec/middleware/raise_tower_error_spec.rb
@@ -1,3 +1,4 @@
+
 require 'faraday'
 require 'ansible_tower_client/middleware/raise_tower_error'
 require_relative '../spec_helper'
@@ -20,11 +21,11 @@ describe AnsibleTowerClient::Middleware::RaiseTowerError do
     end
 
     it "raises ResourceNotFound exception with a status 404" do
-      expect { error.on_complete(env_404) }.to raise_error(Faraday::Error::ResourceNotFound)
+      expect { error.on_complete(env_404) }.to raise_error(AnsibleTowerClient::ResourceNotFoundError)
     end
 
     it "raises ConnectionFailed exception with a status 407" do
-      expect { error.on_complete(env_407) }.to raise_error(Faraday::Error::ConnectionFailed)
+      expect { error.on_complete(env_407) }.to raise_error(AnsibleTowerClient::ConnectionError)
     end
   end
 end


### PR DESCRIPTION
Fixes #70 