### PR TITLE
Fix error logging after changing error response classes

### DIFF
--- a/lib/ansible_tower_client/api.rb
+++ b/lib/ansible_tower_client/api.rb
@@ -83,13 +83,7 @@ module AnsibleTowerClient
     rescue Faraday::SSLError => err
       raise AnsibleTowerClient::SSLError, err
     rescue Faraday::ClientError => err
-      raise if err.response.nil?
-      response = err.response
-      logger.debug { "#{self.class.name} #{err.class.name} #{response.pretty_inspect}" }
-      message   = JSON.parse(response[:body])['detail'] rescue nil
-      message ||= DEFAULT_ERROR_MSG
-      logger.error("#{self.class.name} #{err.class.name} #{message}")
-      raise AnsibleTowerClient::ConnectionError, message
+      raise AnsibleTowerClient::ConnectionError, err
     end
 
     def respond_to_missing?(method, _include_private = false)

--- a/lib/ansible_tower_client/middleware/raise_tower_error.rb
+++ b/lib/ansible_tower_client/middleware/raise_tower_error.rb
@@ -1,9 +1,16 @@
 module AnsibleTowerClient
   module Middleware
     class RaiseTowerError < Faraday::Response::Middleware
+      include Logging
       CLIENT_ERROR_STATUSES = 400...600
 
       def on_complete(env)
+        return unless CLIENT_ERROR_STATUSES.include?(env[:status])
+        logger.debug { "#{self.class.name} Raw Response:\n#{env.pretty_inspect}" }
+        message   = JSON.parse(env.body).pretty_inspect rescue nil
+        message ||= env.body
+        logger.error("#{self.class.name} Response Body:\n#{message}")
+
         case env[:status]
         when 402
           raise AnsibleTowerClient::UnlicensedFeatureError
@@ -12,7 +19,7 @@ module AnsibleTowerClient
         when 407
           # mimic the behavior that we get with proxy requests with HTTPS
           raise AnsibleTowerClient::ConnectionError, %(407 "Proxy Authentication Required ")
-        when CLIENT_ERROR_STATUSES
+        else
           raise AnsibleTowerClient::ClientError, env.body
         end
       end

--- a/spec/middleware/raise_tower_error_spec.rb
+++ b/spec/middleware/raise_tower_error_spec.rb
@@ -1,7 +1,5 @@
-
 require 'faraday'
 require 'ansible_tower_client/middleware/raise_tower_error'
-require_relative '../spec_helper'
 
 describe AnsibleTowerClient::Middleware::RaiseTowerError do
   context "Faraday::Error" do

--- a/spec/middleware/raise_tower_error_spec.rb
+++ b/spec/middleware/raise_tower_error_spec.rb
@@ -12,19 +12,49 @@ describe AnsibleTowerClient::Middleware::RaiseTowerError do
 
     let(:error) { AnsibleTowerClient::Middleware::RaiseTowerError.new }
 
+    around do |example|
+      AnsibleTowerClient.logger.level = 0
+      example.run
+      AnsibleTowerClient.logger.level = 1
+    end
+
     it "raises ClientError and returns the body message with a status 400" do
+      expect(AnsibleTowerClient.logger).to receive(:debug) do |&block|
+        expect(block.call).to eq("#{described_class.name} Raw Response:\n#{env_400.pretty_inspect}")
+      end
+      expect(AnsibleTowerClient.logger).to receive(:error).with(
+        "AnsibleTowerClient::Middleware::RaiseTowerError Response Body:\nmissing these attributes"
+      )
       expect { error.on_complete(env_400) }.to raise_error(AnsibleTowerClient::ClientError, "missing these attributes")
     end
 
     it "raises UnlicensedFeatureError with a status 402" do
+      expect(AnsibleTowerClient.logger).to receive(:debug) do |&block|
+        expect(block.call).to eq("#{described_class.name} Raw Response:\n#{env_402.pretty_inspect}")
+      end
+      expect(AnsibleTowerClient.logger).to receive(:error).with(
+        "AnsibleTowerClient::Middleware::RaiseTowerError Response Body:\nmissing these attributes"
+      )
       expect { error.on_complete(env_402) }.to raise_error(AnsibleTowerClient::UnlicensedFeatureError)
     end
 
     it "raises ResourceNotFound exception with a status 404" do
+      expect(AnsibleTowerClient.logger).to receive(:debug) do |&block|
+        expect(block.call).to eq("#{described_class.name} Raw Response:\n#{env_404.pretty_inspect}")
+      end
+      expect(AnsibleTowerClient.logger).to receive(:error).with(
+        "AnsibleTowerClient::Middleware::RaiseTowerError Response Body:\nmissing these attributes"
+      )
       expect { error.on_complete(env_404) }.to raise_error(AnsibleTowerClient::ResourceNotFoundError)
     end
 
     it "raises ConnectionFailed exception with a status 407" do
+      expect(AnsibleTowerClient.logger).to receive(:debug) do |&block|
+        expect(block.call).to eq("#{described_class.name} Raw Response:\n#{env_407.pretty_inspect}")
+      end
+      expect(AnsibleTowerClient.logger).to receive(:error).with(
+        "AnsibleTowerClient::Middleware::RaiseTowerError Response Body:\nmissing these attributes"
+      )
       expect { error.on_complete(env_407) }.to raise_error(AnsibleTowerClient::ConnectionError)
     end
   end


### PR DESCRIPTION
Log the error from the middleware to avoid rerescuing AnsibleTowerClient errors in Api class.

This will log:
```
[----] D, [2017-02-22T17:47:41.987732 #17232:c27108] DEBUG -- : AnsibleTowerClient::Middleware::RaiseTowerError Response:
#<struct Faraday::Env
 method=:post,
 body=
  "{\"inventory\":[\"Job Template 'inventory' is missing or undefined.\"]}",
 url=#<URI::HTTPS https://10.x.x.x/api/v1/job_templates/7/launch/>,
 request=
  #<struct Faraday::RequestOptions
   params_encoder=nil,
   proxy=nil,
   bind=nil,
   timeout=nil,
   open_timeout=nil,
   boundary=nil,
   oauth=nil>,
 request_headers=
  {"Authorization"=>"Basic YWRtaW46cGFzc3dvcmQxMjM=",
   "User-Agent"=>"Faraday v0.9.2",
   "Content-Type"=>"application/json"},
 ssl=
  #<struct Faraday::SSLOptions
   verify=false,
   ca_file=nil,
   ca_path=nil,
   verify_mode=nil,
   cert_store=nil,
   client_cert=nil,
   client_key=nil,
   certificate=nil,
   private_key=nil,
   verify_depth=nil,
   version=nil>,
 parallel_manager=nil,
 params=nil,
 response=
  #<Faraday::Response:0x0000000ff38928
   @env=#<struct Faraday::Env:...>,
   @on_complete_callbacks=[]>,
 response_headers=
  {"date"=>"Wed, 22 Feb 2017 22:47:39 GMT",
   "server"=>
    "Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5",
   "vary"=>"Accept,Cookie",
   "allow"=>"GET, POST, HEAD, OPTIONS",
   "x-api-time"=>"0.115s",
   "content-length"=>"67",
   "connection"=>"close",
   "content-type"=>"application/json"},
 status=400>
[----] E, [2017-02-22T17:47:41.988213 #17232:c27108] ERROR -- : AnsibleTowerClient::Middleware::RaiseTowerError Response Body:
{"inventory"=>["Job Template 'inventory' is missing or undefined."]}
```