### PR TITLE
Override RAW attributes

### DIFF
--- a/lib/ansible_tower_client/base_model.rb
+++ b/lib/ansible_tower_client/base_model.rb
@@ -82,7 +82,11 @@ module AnsibleTowerClient
     def update_attributes!(attributes)
       @api.patch(url, attributes.to_json)
       attributes.each do |method_name, value|
-        send("#{method_name}=", value)
+        if override_raw_attributes[method_name]
+          send("#{override_raw_attributes[method_name]}=", value)
+        else
+          send("#{method_name}=", value)
+        end
       end
       true
     end
@@ -143,6 +147,10 @@ module AnsibleTowerClient
       destroy!
     rescue AnsibleTowerClient::Error
       false
+    end
+
+    def override_raw_attributes
+      {}
     end
 
     def hashify(attribute)

--- a/lib/ansible_tower_client/base_models/job_template.rb
+++ b/lib/ansible_tower_client/base_models/job_template.rb
@@ -21,5 +21,9 @@ module AnsibleTowerClient
     def extra_vars_hash
       extra_vars.empty? ? {} : hashify(:extra_vars)
     end
+
+    def override_raw_attributes
+      { :credential => :credential_id, :inventory => :inventory_id, :project => :project_id }
+    end
   end
 end

--- a/spec/job_template_spec.rb
+++ b/spec/job_template_spec.rb
@@ -34,4 +34,16 @@ describe AnsibleTowerClient::JobTemplate do
       described_class.new(api, raw_instance).launch(json_with_limit)
     end
   end
+
+  context 'override_raw_attributes' do
+    let(:obj) { described_class.new(instance_double("Faraday::Connection"), raw_instance) }
+    let(:instance_api) { obj.instance_variable_get(:@api) }
+
+    it 'translates :project to :project_id for update_attributes' do
+      raw_instance[:project_id] = 10
+      expect(instance_api).to receive(:patch).and_return(instance_double("Faraday::Result", :body => raw_instance.to_json))
+      expect(obj.update_attributes(:project => '5')).to eq true
+      expect(obj.project_id).to eq '5'
+    end
+  end
 end


### PR DESCRIPTION
the `HashModel`  rewrites integer based attributes into attribute_id. This PR rewrites the raw values returned from
an API response into the correct '_id' style

https://www.pivotaltracker.com/story/show/140521307