### PR TITLE
Expose plays, JobEvent

### DIFF
--- a/lib/ansible_tower_client.rb
+++ b/lib/ansible_tower_client.rb
@@ -20,6 +20,7 @@ require "ansible_tower_client/base_models/inventory"
 require "ansible_tower_client/base_models/inventory_source"
 require "ansible_tower_client/base_models/inventory_update"
 require "ansible_tower_client/base_models/job"
+require "ansible_tower_client/base_models/job_event"
 require "ansible_tower_client/base_models/job_template"
 require "ansible_tower_client/base_models/project"
 

--- a/lib/ansible_tower_client/api.rb
+++ b/lib/ansible_tower_client/api.rb
@@ -59,6 +59,10 @@ module AnsibleTowerClient
       Collection.new(self, job_class)
     end
 
+    def job_events
+      Collection.new(self, job_event_class)
+    end
+
     def job_templates
       Collection.new(self, job_template_class)
     end
@@ -126,6 +130,10 @@ module AnsibleTowerClient
 
     def job_class
       @job_class ||= AnsibleTowerClient::Job
+    end
+
+    def job_event_class
+      @job_event_class ||= AnsibleTowerClient::JobEvent
     end
 
     def job_template_class

--- a/lib/ansible_tower_client/base_models/job.rb
+++ b/lib/ansible_tower_client/base_models/job.rb
@@ -4,6 +4,10 @@ module AnsibleTowerClient
       extra_vars.empty? ? {} : hashify(:extra_vars)
     end
 
+    def job_plays
+      Collection.new(api).find_all_by_url(related["job_plays"])
+    end
+
     def stdout
       out_url = related['stdout']
       return unless out_url

--- a/lib/ansible_tower_client/base_models/job_event.rb
+++ b/lib/ansible_tower_client/base_models/job_event.rb
@@ -1,0 +1,4 @@
+module AnsibleTowerClient
+  class JobEvent < BaseModel
+  end
+end

--- a/spec/factories/responses.rb
+++ b/spec/factories/responses.rb
@@ -44,6 +44,7 @@ FactoryGirl.define do
     trait(:job_template) { [description, extra_vars] }
     trait(:job)          { [description, extra_vars] }
     trait(:project)      { [description, organization] }
+    trait(:job_event)    { [url] }
 
     initialize_with { AnsibleTowerClient::FactoryHelper.stringify_attribute_keys(attributes) }
   end

--- a/spec/job_event_spec.rb
+++ b/spec/job_event_spec.rb
@@ -1,0 +1,10 @@
+describe AnsibleTowerClient::JobEvent do
+  let(:url)                 { "example.com/api/v1/job_events" }
+  let(:api)                 { AnsibleTowerClient::Api.new(instance_double("Faraday::Connection")) }
+  let(:collection)          { api.job_events }
+  let(:raw_url_collection)  { build(:response_url_collection, :klass => described_class, :url => url) }
+  let(:raw_instance)        { build(:response_instance, :group, :klass => described_class) }
+
+  include_examples "Collection Methods"
+  include_examples "Api Methods"
+end

--- a/spec/job_spec.rb
+++ b/spec/job_spec.rb
@@ -3,8 +3,8 @@ describe AnsibleTowerClient::Job do
   let(:api)            { AnsibleTowerClient::Api.new(instance_double("Faraday::Connection")) }
   let(:collection)     { api.jobs }
   let(:raw_collection) { build(:response_collection, :klass => described_class) }
-  let(:raw_url_collection)  { build(:response_url_collection, :klass => described_class, :url => url) }
-  let(:raw_instance)   { build(:response_instance, :job, :klass => described_class) }
+  let(:raw_url_collection) { build(:response_url_collection, :klass => described_class, :url => url) }
+  let(:raw_instance) { build(:response_instance, :job, :klass => described_class) }
   let(:raw_instance_no_extra_vars) { build(:response_instance, :job_template, :klass => described_class, :extra_vars => '') }
   let(:raw_instance_no_output)     { build(:response_instance, :job_template, :klass => described_class, :related => {}) }
 
@@ -34,6 +34,21 @@ describe AnsibleTowerClient::Job do
         obj = described_class.new(instance_double("AnsibleTowerClient::Api"), raw_instance_no_extra_vars)
         expect(obj.extra_vars_hash).to eq({})
       end
+    end
+  end
+
+  context '#job_plays' do
+    let(:url)            { "example.com/api/v1/job_plays" }
+    let(:job_collection) { build(:response_collection, :klass => described_class) }
+    let(:job_events)     { build(:response_url_collection, :klass => AnsibleTowerClient::JobEvent, :url => url) }
+    it "returns a collection of AnsibleTowerClient::JobEvents" do
+      expect(AnsibleTowerClient::Collection).to receive(:new).with(api).and_return(job_collection)
+      expect(job_collection).to receive(:find_all_by_url).and_return(job_events['results'])
+      results = described_class.new(api, raw_instance).job_plays.first
+      expect(results).to include(
+        "type" => "job_event",
+        "url"  => "example.com/api/v1/job_plays",
+      )
     end
   end
 


### PR DESCRIPTION
1. Expose `job_plays` off of `AnsibleTowerClient::Job`
2. Add `job_events` as a Collection
3. Add `AnsibleTowerClient::JobEvent` 

Testing Notes

1. Lookup a Job
`job = connection.api.jobs.find n`

2. Call job_plays off of said job
`job.job_plays.first`

3. Returned object will be a `AnsibleTowerClient::JobEvent`
