### PR TITLE
Override type when appropriate

### DIFF
--- a/lib/ansible_tower_client.rb
+++ b/lib/ansible_tower_client.rb
@@ -21,6 +21,7 @@ require "ansible_tower_client/base_models/inventory_source"
 require "ansible_tower_client/base_models/inventory_update"
 require "ansible_tower_client/base_models/job"
 require "ansible_tower_client/base_models/job_event"
+require "ansible_tower_client/base_models/job_play"
 require "ansible_tower_client/base_models/job_template"
 require "ansible_tower_client/base_models/project"
 

--- a/lib/ansible_tower_client/api.rb
+++ b/lib/ansible_tower_client/api.rb
@@ -63,6 +63,10 @@ module AnsibleTowerClient
       Collection.new(self, job_event_class)
     end
 
+    def job_plays
+      Collection.new(self, job_play_class)
+    end
+
     def job_templates
       Collection.new(self, job_template_class)
     end
@@ -134,6 +138,10 @@ module AnsibleTowerClient
 
     def job_event_class
       @job_event_class ||= AnsibleTowerClient::JobEvent
+    end
+
+    def job_play_class
+      @job_play_class ||= AnsibleTowerClient::JobPlay
     end
 
     def job_template_class

--- a/lib/ansible_tower_client/base_model.rb
+++ b/lib/ansible_tower_client/base_model.rb
@@ -10,10 +10,6 @@ module AnsibleTowerClient
       base_class.to_s.split(/::/)[1].tableize.to_s.freeze
     end
 
-    def self.force_type_override
-      false
-    end
-
     # Constructs and returns a new JSON wrapper class. Pass in a plain
     # JSON string and it will automatically give you accessor methods
     # that make it behave like a typical Ruby object. You may also pass

--- a/lib/ansible_tower_client/base_model.rb
+++ b/lib/ansible_tower_client/base_model.rb
@@ -10,6 +10,10 @@ module AnsibleTowerClient
       base_class.to_s.split(/::/)[1].tableize.to_s.freeze
     end
 
+    def self.force_type_override
+      false
+    end
+
     # Constructs and returns a new JSON wrapper class. Pass in a plain
     # JSON string and it will automatically give you accessor methods
     # that make it behave like a typical Ruby object. You may also pass

--- a/lib/ansible_tower_client/base_models/host.rb
+++ b/lib/ansible_tower_client/base_models/host.rb
@@ -1,7 +1,7 @@
 module AnsibleTowerClient
   class Host < BaseModel
     def groups
-      Collection.new(api).find_all_by_url(related["groups"])
+      Collection.new(api, api.group_class).find_all_by_url(related["groups"])
     end
   end
 end

--- a/lib/ansible_tower_client/base_models/inventory.rb
+++ b/lib/ansible_tower_client/base_models/inventory.rb
@@ -1,7 +1,7 @@
 module AnsibleTowerClient
   class Inventory < BaseModel
     def inventory_sources
-      Collection.new(api).find_all_by_url(related['inventory_sources'])
+      Collection.new(api, api.inventory_source_class).find_all_by_url(related['inventory_sources'])
     end
 
     def update_all_inventory_sources

--- a/lib/ansible_tower_client/base_models/job.rb
+++ b/lib/ansible_tower_client/base_models/job.rb
@@ -5,7 +5,7 @@ module AnsibleTowerClient
     end
 
     def job_plays
-      Collection.new(api).find_all_by_url(related["job_plays"])
+      Collection.new(api, api.job_play_class).find_all_by_url(related["job_plays"])
     end
 
     def stdout

--- a/lib/ansible_tower_client/base_models/job_play.rb
+++ b/lib/ansible_tower_client/base_models/job_play.rb
@@ -1,7 +1,4 @@
 module AnsibleTowerClient
   class JobPlay < BaseModel
-    def self.force_type_override
-      true
-    end
   end
 end

--- a/lib/ansible_tower_client/base_models/job_play.rb
+++ b/lib/ansible_tower_client/base_models/job_play.rb
@@ -1,0 +1,7 @@
+module AnsibleTowerClient
+  class JobPlay < BaseModel
+    def self.force_type_override
+      true
+    end
+  end
+end

--- a/lib/ansible_tower_client/collection.rb
+++ b/lib/ansible_tower_client/collection.rb
@@ -66,7 +66,7 @@ module AnsibleTowerClient
     end
 
     def build_object(result)
-      (klass || class_from_type(result[‘type’])).new(api, result)
+      (klass || class_from_type(result['type'])).new(api, result)
     end
   end
 end

--- a/lib/ansible_tower_client/collection.rb
+++ b/lib/ansible_tower_client/collection.rb
@@ -41,14 +41,7 @@ module AnsibleTowerClient
     private
 
     def class_from_type(type)
-      api.send("#{force_type?(type)}_class")
-    end
-
-    def force_type?(type)
-      if @klass && @klass.force_type_override
-        return @klass.to_s.tableize.singularize.split("/").last
-      end
-      type
+      api.send("#{type}_class")
     end
 
     def fetch_more_results(next_page, get_options)
@@ -73,7 +66,7 @@ module AnsibleTowerClient
     end
 
     def build_object(result)
-      class_from_type(result["type"]).new(api, result)
+      (klass || class_from_type(result[‘type’])).new(api, result)
     end
   end
 end

--- a/lib/ansible_tower_client/collection.rb
+++ b/lib/ansible_tower_client/collection.rb
@@ -41,7 +41,14 @@ module AnsibleTowerClient
     private
 
     def class_from_type(type)
-      api.send("#{type}_class")
+      api.send("#{force_type?(type)}_class")
+    end
+
+    def force_type?(type)
+      if @klass && @klass.force_type_override
+        return @klass.to_s.tableize.singularize.split("/").last
+      end
+      type
     end
 
     def fetch_more_results(next_page, get_options)

--- a/spec/factories/responses.rb
+++ b/spec/factories/responses.rb
@@ -25,7 +25,7 @@ FactoryGirl.define do
     klass      ""
     type       { AnsibleTowerClient::FactoryHelper.underscore_string(klass.namespace.last) }
     name       { "#{type}-#{id}" }
-    url        { "/api/v1/#{klass.endpoint}/#{id}/" }
+    url        { "/api/v1/endpoint/" }
     related    { {"survey_spec" => "example.com/api", 'inventory' => 'inventory link', 'stdout' => 'example.com/api'} }
     limit      { "" }
 
@@ -35,7 +35,7 @@ FactoryGirl.define do
     trait(:inventory_id) { inventory { rand(500) } }
     trait(:kind)         { kind { "machine" } }
     trait(:organization) { organization { rand(500) } }
-    trait(:url)          { "/api/v1/#{klass}/#{rand(10)}" }
+    trait(:url)          { url { "api/v1/endpoint/#{rand(10)}" } }
     trait(:username)     { username { "random username" } }
 
     trait(:credential)   { [description, kind, username] }

--- a/spec/factories/responses.rb
+++ b/spec/factories/responses.rb
@@ -45,6 +45,7 @@ FactoryGirl.define do
     trait(:job)          { [description, extra_vars] }
     trait(:project)      { [description, organization] }
     trait(:job_event)    { [url] }
+    trait(:job_play)     { [url] }
 
     initialize_with { AnsibleTowerClient::FactoryHelper.stringify_attribute_keys(attributes) }
   end

--- a/spec/job_event_spec.rb
+++ b/spec/job_event_spec.rb
@@ -3,7 +3,7 @@ describe AnsibleTowerClient::JobEvent do
   let(:api)                 { AnsibleTowerClient::Api.new(instance_double("Faraday::Connection")) }
   let(:collection)          { api.job_events }
   let(:raw_url_collection)  { build(:response_url_collection, :klass => described_class, :url => url) }
-  let(:raw_instance)        { build(:response_instance, :group, :klass => described_class) }
+  let(:raw_instance)        { build(:response_instance, :job_event, :klass => described_class) }
 
   include_examples "Collection Methods"
   include_examples "Api Methods"

--- a/spec/job_play_spec.rb
+++ b/spec/job_play_spec.rb
@@ -1,0 +1,21 @@
+require 'json'
+
+describe AnsibleTowerClient::JobPlay do
+  let(:url)                 { "example.com/api/v1/job_plays" }
+  let(:api)                 { AnsibleTowerClient::Api.new(instance_double("Faraday::Connection")) }
+  let(:collection)          { api.job_plays }
+  let(:raw_collection)      { build(:response_collection, :klass => described_class) }
+  let(:raw_url_collection)  { build(:response_url_collection, :klass => described_class, :url => url) }
+  let(:raw_instance)        { build(:response_instance, :job_play, :klass => described_class) }
+
+  include_examples "Collection Methods"
+  include_examples "Crud Methods"
+  include_examples "Api Methods"
+
+  it "#initialize instantiates an #{described_class} from a hash" do
+    obj = described_class.new(instance_double("AnsibleTowerClient::Api"), raw_instance)
+
+    expect(obj).to              be_a described_class
+    expect(obj.url).to          be_a String
+  end
+end

--- a/spec/job_spec.rb
+++ b/spec/job_spec.rb
@@ -40,7 +40,7 @@ describe AnsibleTowerClient::Job do
   context '#job_plays' do
     let(:url)            { "example.com/api/v1/job_plays" }
     let(:job_collection) { build(:response_collection, :klass => described_class) }
-    let(:job_plays)     { build(:response_url_collection, :klass => AnsibleTowerClient::JobPlay, :url => url) }
+    let(:job_plays)      { build(:response_url_collection, :klass => AnsibleTowerClient::JobPlay, :url => url) }
     it "returns a collection of AnsibleTowerClient::JobPlays" do
       expect(AnsibleTowerClient::Collection).to receive(:new).with(api, api.job_play_class).and_return(job_collection)
       expect(job_collection).to receive(:find_all_by_url).and_return(job_plays['results'])

--- a/spec/job_spec.rb
+++ b/spec/job_spec.rb
@@ -40,13 +40,13 @@ describe AnsibleTowerClient::Job do
   context '#job_plays' do
     let(:url)            { "example.com/api/v1/job_plays" }
     let(:job_collection) { build(:response_collection, :klass => described_class) }
-    let(:job_events)     { build(:response_url_collection, :klass => AnsibleTowerClient::JobEvent, :url => url) }
-    it "returns a collection of AnsibleTowerClient::JobEvents" do
-      expect(AnsibleTowerClient::Collection).to receive(:new).with(api).and_return(job_collection)
-      expect(job_collection).to receive(:find_all_by_url).and_return(job_events['results'])
+    let(:job_plays)     { build(:response_url_collection, :klass => AnsibleTowerClient::JobPlay, :url => url) }
+    it "returns a collection of AnsibleTowerClient::JobPlays" do
+      expect(AnsibleTowerClient::Collection).to receive(:new).with(api, api.job_play_class).and_return(job_collection)
+      expect(job_collection).to receive(:find_all_by_url).and_return(job_plays['results'])
       results = described_class.new(api, raw_instance).job_plays.first
       expect(results).to include(
-        "type" => "job_event",
+        "type" => "job_play",
         "url"  => "example.com/api/v1/job_plays",
       )
     end


### PR DESCRIPTION
The Tower API returns `job_event` summary types when querying the `/job_plays/` endpoint. 

In this PR we create a mechanism that allows us to force a type (in this case `AnsibleTowerClient::JobPlay` when we don't want to use the `type` column passed back by the Tower provider.