### PR TITLE
Allow formatted stdout, default to plain text

### DIFF
--- a/lib/ansible_tower_client/base_models/job.rb
+++ b/lib/ansible_tower_client/base_models/job.rb
@@ -8,10 +8,10 @@ module AnsibleTowerClient
       Collection.new(api, api.job_play_class).find_all_by_url(related["job_plays"])
     end
 
-    def stdout
+    def stdout(format = 'txt')
       out_url = related['stdout']
       return unless out_url
-      api.get("#{out_url}?format=txt").body
+      api.get("#{out_url}?format=#{format}").body
     end
   end
 end

--- a/spec/job_spec.rb
+++ b/spec/job_spec.rb
@@ -55,9 +55,15 @@ describe AnsibleTowerClient::Job do
   context '#stdout' do
     describe "exists" do
       let(:stdout) { "Ansible Tower job output" }
-      it "returns stdout" do
-        expect(api).to receive(:get).and_return(instance_double("Faraday::Result", :body => stdout))
+
+      it "returns stdout default to plain text" do
+        expect(api).to receive(:get).with(/format=txt/).and_return(instance_double("Faraday::Result", :body => stdout))
         expect(described_class.new(api, raw_instance).stdout).to eq(stdout)
+      end
+
+      it "returns formatted text per request" do
+        expect(api).to receive(:get).with(/format=html/).and_return(instance_double("Faraday::Result", :body => stdout))
+        expect(described_class.new(api, raw_instance).stdout('html')).to eq(stdout)
       end
     end
 


### PR DESCRIPTION
API already supports differently formatted stdout.