### PR TITLE
Remove extra cruft in activity_stream_spec.rb

### DIFF
--- a/spec/activity_stream_spec.rb
+++ b/spec/activity_stream_spec.rb
@@ -1,9 +1,5 @@
 describe AnsibleTowerClient::ActivityStream do
-  let(:url)                 { "example.com/api/v1/activity_stream" }
-  let(:api)                 { AnsibleTowerClient::Api.new(instance_double("Faraday::Connection")) }
-  let(:collection)          { api.activity_stream }
-  let(:raw_url_collection)  { build(:response_url_collection, :klass => described_class, :url => url) }
-  let(:raw_instance)        { build(:response_instance, :group, :klass => described_class) }
+  let(:url) { "example.com/api/v1/activity_stream" }
 
   include_examples "Collection Methods"
   include_examples "Api Methods"


### PR DESCRIPTION
Depends on https://github.com/ansible/ansible_tower_client_ruby/pull/88

None of these `let`s are used in the specs for this model.  Removing them to avoid confusion.