### PR TITLE
Add MockApi for testing

### DIFF
--- a/spec/ad_hoc_command_spec.rb
+++ b/spec/ad_hoc_command_spec.rb
@@ -1,15 +1,11 @@
 describe AnsibleTowerClient::AdHocCommand do
-  let(:url)                 { "example.com/api/v1/ad_hoc_command_update/10" }
-  let(:api)                 { AnsibleTowerClient::Api.new(instance_double("Faraday::Connection")) }
-  let(:collection)          { api.ad_hoc_commands }
-  let(:raw_collection)      { build(:response_collection, :klass => described_class) }
-  let(:raw_url_collection)  { build(:response_url_collection, :klass => described_class, :url => url) }
-  let(:raw_instance)        { build(:response_instance, :klass => described_class) }
+  let(:api)          { AnsibleTowerClient::Api.new(AnsibleTowerClient::MockApi.new) }
+  let(:raw_instance) { build(:response_instance, :klass => described_class) }
 
   include_examples "Crud Methods"
 
   it "#initialize instantiates an #{described_class} from a hash" do
-    obj = described_class.new(instance_double("AnsibleTowerClient::Api"), raw_instance)
+    obj = api.ad_hoc_commands.all.first
 
     expect(obj).to      be_a described_class
     expect(obj.id).to   be_a Integer

--- a/spec/api_spec.rb
+++ b/spec/api_spec.rb
@@ -1,7 +1,7 @@
 require 'faraday'
 
 describe AnsibleTowerClient::Api do
-  let(:faraday_connection) { instance_double("Faraday::Connection") }
+  let(:faraday_connection) { AnsibleTowerClient::MockApi.new }
 
   subject { described_class.new(faraday_connection) }
 
@@ -14,38 +14,16 @@ describe AnsibleTowerClient::Api do
   end
 
   context "helper methods" do
-    let(:config_body) do
-      {:eula => 'text',
-       :license_info => {:deployment_id => 'werwer', :contact_name => 'Fred Tester'},
-       :version => '2.4.2', :ansible_version => '1.9.4',
-       :project_local_paths => []}.to_json
-    end
-
-    let(:credentials_body) do
-      {:count => 1, :next => nil, :previous => nil,
-       :results => [{:id => 1, :type => 'user',
-                     :url => '/api/v1/users/1',
-                     :username => 'admin'}]}.to_json
-    end
-
-    let(:faraday_connection) { instance_double("Faraday::Connection", :get => get) }
-
-    let(:api) { described_class.new(faraday_connection) }
-
     context "requiring a connection" do
-      before { allow(Faraday).to receive(:new).and_return(faraday_connection) }
-
       describe "config" do
-        let(:get) { instance_double("Faraday::Result", :body => config_body) }
-
         it "#config returns the server config" do
-          json = api.config
+          json = subject.config
           expect(json['eula']).to eq "text"
           expect(json['license_info']).to be_a Hash
         end
 
         it "#version returns the ansible tower version" do
-          expect(api.version).to eq "2.4.2"
+          expect(subject.version).to eq "3.0.1"
         end
       end
 
@@ -53,7 +31,7 @@ describe AnsibleTowerClient::Api do
         let(:get) { instance_double("Faraday::Result", :body => credentials_body) }
 
         it "returns the username" do
-          expect(api.verify_credentials).to eq "admin"
+          expect(subject.verify_credentials).to eq "admin"
         end
       end
     end

--- a/spec/api_spec.rb
+++ b/spec/api_spec.rb
@@ -1,5 +1,3 @@
-require 'faraday'
-
 describe AnsibleTowerClient::Api do
   let(:faraday_connection) { AnsibleTowerClient::MockApi.new }
 

--- a/spec/credential_spec.rb
+++ b/spec/credential_spec.rb
@@ -1,20 +1,16 @@
 describe AnsibleTowerClient::Credential do
-  let(:url)                 { "example.com/api/v1/credentials/10" }
-  let(:api)                 { AnsibleTowerClient::Api.new(instance_double("Faraday::Connection")) }
-  let(:collection)          { api.credentials }
-  let(:raw_collection)      { build(:response_collection, :klass => described_class) }
-  let(:raw_url_collection)  { build(:response_url_collection, :klass => described_class, :url => url) }
-  let(:raw_instance)        { build(:response_instance, :credential, :klass => described_class, :kind => "scm") }
+  let(:api)          { AnsibleTowerClient::Api.new(AnsibleTowerClient::MockApi.new) }
+  let(:raw_instance) { build(:response_instance, :credential, :klass => described_class) }
 
   include_examples "Crud Methods"
 
   it "#initialize instantiates an #{described_class} from a hash" do
-    obj = described_class.new(instance_double("AnsibleTowerClient::Api"), raw_instance)
+    obj = api.credentials.all.first
 
     expect(obj).to              be_a described_class
     expect(obj.id).to           be_a Integer
     expect(obj.url).to          be_a String
-    expect(obj.kind).to         eq "scm"
+    expect(obj.kind).to         eq "aws"
     expect(obj.username).to     be_a String
     expect(obj.name).to         be_a String
   end

--- a/spec/group_spec.rb
+++ b/spec/group_spec.rb
@@ -1,16 +1,13 @@
 describe AnsibleTowerClient::Group do
-  let(:url)                 { "example.com/api/v1/groups" }
-  let(:api)                 { AnsibleTowerClient::Api.new(instance_double("Faraday::Connection")) }
-  let(:collection)          { api.groups }
-  let(:raw_collection)      { build(:response_collection, :klass => described_class) }
-  let(:raw_url_collection)  { build(:response_url_collection, :klass => described_class, :url => url) }
-  let(:raw_instance)        { build(:response_instance, :group, :klass => described_class) }
+  let(:url)          { "example.com/api/v1/groups" }
+  let(:api)          { AnsibleTowerClient::Api.new(AnsibleTowerClient::MockApi.new) }
+  let(:raw_instance) { build(:response_instance, :group, :klass => described_class) }
 
-  include_examples "Crud Methods"
   include_examples "Api Methods"
+  include_examples "Crud Methods"
 
   it "#initialize instantiates an #{described_class} from a hash" do
-    obj = described_class.new(instance_double("AnsibleTowerClient::Api"), raw_instance)
+    obj = api.groups.all.first
 
     expect(obj).to              be_a described_class
     expect(obj.id).to           be_a Integer

--- a/spec/host_spec.rb
+++ b/spec/host_spec.rb
@@ -1,16 +1,13 @@
 describe AnsibleTowerClient::Host do
-  let(:url)                 { "example.com/api/v1/hosts" }
-  let(:api)                 { AnsibleTowerClient::Api.new(instance_double("Faraday::Connection")) }
-  let(:collection)          { api.hosts }
-  let(:raw_collection)      { build(:response_collection, :klass => described_class) }
-  let(:raw_url_collection)  { build(:response_url_collection, :klass => described_class, :url => url) }
-  let(:raw_instance)        { build(:response_instance, :host, :klass => described_class) }
+  let(:url)          { "example.com/api/v1/hosts" }
+  let(:api)          { AnsibleTowerClient::Api.new(AnsibleTowerClient::MockApi.new) }
+  let(:raw_instance) { build(:response_instance, :host, :klass => described_class) }
 
-  include_examples "Crud Methods"
   include_examples "Api Methods"
+  include_examples "Crud Methods"
 
   it "#initialize instantiates an #{described_class} from a hash" do
-    obj = described_class.new(instance_double("AnsibleTowerClient::Api"), raw_instance)
+    obj = api.hosts.all.first
 
     expect(obj).to              be_a described_class
     expect(obj.id).to           be_a Integer

--- a/spec/inventory_source_spec.rb
+++ b/spec/inventory_source_spec.rb
@@ -1,15 +1,12 @@
 describe AnsibleTowerClient::InventorySource do
-  let(:url)                 { "example.com/api/v1/inventory_sources" }
-  let(:api)                 { AnsibleTowerClient::Api.new(instance_double("Faraday::Connection")) }
-  let(:collection)          { api.inventory_sources }
-  let(:raw_collection)      { build(:response_collection, :klass => described_class) }
-  let(:raw_url_collection)  { build(:response_url_collection, :klass => described_class, :url => url) }
-  let(:raw_instance)        { build(:response_instance, :klass => described_class) }
+  let(:url)          { "example.com/api/v1/inventory_sources" }
+  let(:api)          { AnsibleTowerClient::Api.new(AnsibleTowerClient::MockApi.new) }
+  let(:raw_instance) { build(:response_instance, :klass => described_class) }
 
   include_examples "Api Methods"
 
   it "#initialize instantiates an #{described_class} from a hash" do
-    obj = described_class.new(instance_double("AnsibleTowerClient::Api"), raw_instance)
+    obj = api.inventory_sources.all.first
 
     expect(obj).to      be_a described_class
     expect(obj.id).to   be_a Integer

--- a/spec/inventory_spec.rb
+++ b/spec/inventory_spec.rb
@@ -1,21 +1,17 @@
 describe AnsibleTowerClient::Inventory do
-  let(:url)                 { "example.com/api/v1/inventories" }
-  let(:api)                 { AnsibleTowerClient::Api.new(instance_double("Faraday::Connection")) }
-  let(:collection)          { api.inventories }
-  let(:raw_collection)      { build(:response_collection, :klass => described_class) }
-  let(:raw_url_collection)  { build(:response_url_collection, :klass => described_class, :url => url) }
-  let(:inventory_source)    { build(:response_url_collection, :klass => AnsibleTowerClient::InventorySource) }
-  let(:raw_instance)        { build(:response_instance, :klass => described_class) }
+  let(:url)              { "example.com/api/v1/inventories" }
+  let(:api)              { AnsibleTowerClient::Api.new(AnsibleTowerClient::MockApi.new) }
+  let(:inventory_source) { build(:response_url_collection, :klass => AnsibleTowerClient::InventorySource) }
+  let(:raw_instance)     { build(:response_instance, :klass => described_class) }
+  let(:instance)         { api.inventories.all.first }
 
-  include_examples "Crud Methods"
   include_examples "Api Methods"
+  include_examples "Crud Methods"
 
   it "#initialize instantiates an #{described_class} from a hash" do
-    obj = described_class.new(instance_double("AnsibleTowerClient::Api"), raw_instance)
-
-    expect(obj).to      be_a described_class
-    expect(obj.id).to   be_a Integer
-    expect(obj.name).to be_a String
+    expect(instance).to      be_a described_class
+    expect(instance.id).to   be_a Integer
+    expect(instance.name).to be_a String
   end
 
   describe "#inventory_sources" do
@@ -34,23 +30,22 @@ describe AnsibleTowerClient::Inventory do
     let(:inventory_sources) do
       [described_class.new(instance_double("AnsibleTowerClient::Api"), inventory_source)]
     end
-    let(:obj) { described_class.new(instance_double("AnsibleTowerClient::Api"), raw_instance) }
 
     before do
-      expect(obj).to receive(:inventory_sources).and_return(inventory_sources)
+      expect(instance).to receive(:inventory_sources).and_return(inventory_sources)
     end
 
     it "updates an inventory_source if #can_update? is true" do
       expect(inventory_sources.first).to receive(:can_update?).and_return(can_update_true['can_update'])
       expect(inventory_sources.first).to receive(:update).once.and_return(post_result_body)
 
-      obj.update_all_inventory_sources
+      instance.update_all_inventory_sources
     end
 
-    it "does not update an inventory_source if #can_update? is true" do
+    it "does not update an inventory_source if #can_update? is false" do
       expect(inventory_sources.first).to receive(:can_update?).and_return(can_update_false['can_update'])
 
-      obj.update_all_inventory_sources
+      instance.update_all_inventory_sources
     end
   end
 end

--- a/spec/job_event_spec.rb
+++ b/spec/job_event_spec.rb
@@ -1,9 +1,6 @@
 describe AnsibleTowerClient::JobEvent do
-  let(:url)                 { "example.com/api/v1/job_events" }
-  let(:api)                 { AnsibleTowerClient::Api.new(instance_double("Faraday::Connection")) }
-  let(:collection)          { api.job_events }
-  let(:raw_url_collection)  { build(:response_url_collection, :klass => described_class, :url => url) }
-  let(:raw_instance)        { build(:response_instance, :job_event, :klass => described_class) }
+  let(:url) { "example.com/api/v1/job_events" }
+  let(:api) { AnsibleTowerClient::Api.new(AnsibleTowerClient::MockApi.new) }
 
   include_examples "Api Methods"
 end

--- a/spec/job_spec.rb
+++ b/spec/job_spec.rb
@@ -1,18 +1,15 @@
 describe AnsibleTowerClient::Job do
-  let(:url)            { "example.com/api/v1/jobs" }
-  let(:api)            { AnsibleTowerClient::Api.new(instance_double("Faraday::Connection")) }
-  let(:collection)     { api.jobs }
-  let(:raw_collection) { build(:response_collection, :klass => described_class) }
-  let(:raw_url_collection) { build(:response_url_collection, :klass => described_class, :url => url) }
-  let(:raw_instance) { build(:response_instance, :job, :klass => described_class) }
+  let(:url)                        { "example.com/api/v1/jobs" }
+  let(:api)                        { AnsibleTowerClient::Api.new(AnsibleTowerClient::MockApi.new) }
+  let(:raw_instance)               { build(:response_instance, :job, :klass => described_class) }
   let(:raw_instance_no_extra_vars) { build(:response_instance, :job_template, :klass => described_class, :extra_vars => '') }
   let(:raw_instance_no_output)     { build(:response_instance, :job_template, :klass => described_class, :related => {}) }
 
-  include_examples "Crud Methods"
   include_examples "Api Methods"
+  include_examples "Crud Methods"
 
   it "#initialize instantiates an #{described_class} from a hash" do
-    obj = described_class.new(instance_double("AnsibleTowerClient::Api"), raw_instance)
+    obj = api.jobs.all.first
 
     expect(obj).to         be_a described_class
     expect(obj.id).to      be_a Integer
@@ -23,14 +20,14 @@ describe AnsibleTowerClient::Job do
   describe "#extra_vars_hash" do
     describe "#extra_vars exists" do
       it "returns a hashed value" do
-        obj = described_class.new(instance_double("AnsibleTowerClient::Api"), raw_instance)
+        obj = described_class.new(AnsibleTowerClient::MockApi.new, raw_instance)
         expect(obj.extra_vars_hash).to eq('option' => 'lots of options')
       end
     end
 
     describe "#extra_vars does not exist" do
       it "returns an empty hash" do
-        obj = described_class.new(instance_double("AnsibleTowerClient::Api"), raw_instance_no_extra_vars)
+        obj = described_class.new(AnsibleTowerClient::MockApi.new, raw_instance_no_extra_vars)
         expect(obj.extra_vars_hash).to eq({})
       end
     end

--- a/spec/job_template_spec.rb
+++ b/spec/job_template_spec.rb
@@ -1,8 +1,6 @@
 describe AnsibleTowerClient::JobTemplate do
   let(:url)                        { "example.com/api/v1/job_templates" }
-  let(:api)                        { AnsibleTowerClient::Api.new(connection).tap { |a| allow(a).to receive(:config).and_return(config) } }
-  let(:connection)                 { AnsibleTowerClient::MockApi.new }
-  let(:config)                     { {"version" => "1.1"} }
+  let(:api)                        { AnsibleTowerClient::Api.new(AnsibleTowerClient::MockApi.new("1.1")) }
   let(:raw_instance)               { build(:response_instance, :job_template, :klass => described_class) }
   let(:raw_instance_no_extra_vars) { build(:response_instance, :job_template, :klass => described_class, :extra_vars => '') }
   let(:raw_instance_no_survey)     { build(:response_instance, :job_template, :klass => described_class, :related => {}) }

--- a/spec/job_template_spec.rb
+++ b/spec/job_template_spec.rb
@@ -1,21 +1,18 @@
 describe AnsibleTowerClient::JobTemplate do
-  let(:url)                 { "example.com/api/v1/job_templates" }
-  let(:api)                 { AnsibleTowerClient::Api.new(connection).tap { |a| allow(a).to receive(:config).and_return(config) } }
-  let(:collection)          { api.job_templates }
-  let(:connection)          { AnsibleTowerClient::MockApi.new }
-  let(:config)              { {"version" => "1.1"} }
-  let(:raw_collection)      { build(:response_collection, :klass => described_class) }
-  let(:raw_url_collection)  { build(:response_url_collection, :klass => described_class, :url => url) }
-  let(:raw_instance)        { build(:response_instance, :job_template, :klass => described_class) }
+  let(:url)                        { "example.com/api/v1/job_templates" }
+  let(:api)                        { AnsibleTowerClient::Api.new(connection).tap { |a| allow(a).to receive(:config).and_return(config) } }
+  let(:connection)                 { AnsibleTowerClient::MockApi.new }
+  let(:config)                     { {"version" => "1.1"} }
+  let(:raw_instance)               { build(:response_instance, :job_template, :klass => described_class) }
   let(:raw_instance_no_extra_vars) { build(:response_instance, :job_template, :klass => described_class, :extra_vars => '') }
   let(:raw_instance_no_survey)     { build(:response_instance, :job_template, :klass => described_class, :related => {}) }
 
-  include_examples "Crud Methods"
   include_examples "Api Methods"
+  include_examples "Crud Methods"
+  include_examples "JobTemplate#extra_vars_hash"
   include_examples "JobTemplate#initialize"
   include_examples "JobTemplate#survey_spec"
   include_examples "JobTemplate#survey_spec_hash"
-  include_examples "JobTemplate#extra_vars_hash"
 
   describe '#launch' do
     let(:json) { {'extra_vars' => "{\"instance_ids\":[\"i-999c\"],\"state\":\"absent\",\"subnet_id\":\"subnet-887\"}"} }

--- a/spec/job_template_spec.rb
+++ b/spec/job_template_spec.rb
@@ -1,10 +1,8 @@
-require 'faraday' # Only because we're doubling the connection
-
 describe AnsibleTowerClient::JobTemplate do
   let(:url)                 { "example.com/api/v1/job_templates" }
   let(:api)                 { AnsibleTowerClient::Api.new(connection).tap { |a| allow(a).to receive(:config).and_return(config) } }
   let(:collection)          { api.job_templates }
-  let(:connection)          { instance_double("Faraday::Connection") }
+  let(:connection)          { AnsibleTowerClient::MockApi.new }
   let(:config)              { {"version" => "1.1"} }
   let(:raw_collection)      { build(:response_collection, :klass => described_class) }
   let(:raw_url_collection)  { build(:response_url_collection, :klass => described_class, :url => url) }
@@ -35,7 +33,7 @@ describe AnsibleTowerClient::JobTemplate do
   end
 
   context 'override_raw_attributes' do
-    let(:obj) { described_class.new(instance_double("Faraday::Connection"), raw_instance) }
+    let(:obj) { described_class.new(AnsibleTowerClient::MockApi.new, raw_instance) }
     let(:instance_api) { obj.instance_variable_get(:@api) }
 
     it 'translates :project to :project_id for update_attributes' do

--- a/spec/job_template_v2_spec.rb
+++ b/spec/job_template_v2_spec.rb
@@ -1,10 +1,8 @@
-require 'faraday' # Only because we're doubling the connection
-
 describe AnsibleTowerClient::JobTemplateV2 do
   let(:url)                 { "example.com/api/v1/job_templates" }
   let(:api)                 { AnsibleTowerClient::Api.new(connection).tap { |a| allow(a).to receive(:config).and_return(config) } }
   let(:collection)          { api.job_templates }
-  let(:connection)          { instance_double("Faraday::Connection") }
+  let(:connection)          { AnsibleTowerClient::MockApi.new }
   let(:config)              { {"version" => "2.1"} }
   let(:raw_collection)      { build(:response_collection, :klass => described_class.base_class) }
   let(:raw_url_collection)  { build(:response_url_collection, :klass => described_class.base_class, :url => url) }

--- a/spec/job_template_v2_spec.rb
+++ b/spec/job_template_v2_spec.rb
@@ -1,8 +1,7 @@
 describe AnsibleTowerClient::JobTemplateV2 do
   let(:url)                        { "example.com/api/v1/job_templates" }
-  let(:api)                        { AnsibleTowerClient::Api.new(connection).tap { |a| allow(a).to receive(:config).and_return(config) } }
-  let(:connection)                 { AnsibleTowerClient::MockApi.new }
-  let(:config)                     { {"version" => "2.1"} }
+  let(:api)                        { AnsibleTowerClient::Api.new(connection) }
+  let(:connection)                 { AnsibleTowerClient::MockApi.new("2.1") }
   let(:raw_instance)               { build(:response_instance, :job_template, :klass => described_class.base_class) }
   let(:raw_instance_no_extra_vars) { build(:response_instance, :job_template, :klass => described_class.base_class, :extra_vars => '') }
   let(:raw_instance_no_survey)     { build(:response_instance, :job_template, :klass => described_class.base_class, :related => {}) }

--- a/spec/job_template_v2_spec.rb
+++ b/spec/job_template_v2_spec.rb
@@ -1,21 +1,18 @@
 describe AnsibleTowerClient::JobTemplateV2 do
-  let(:url)                 { "example.com/api/v1/job_templates" }
-  let(:api)                 { AnsibleTowerClient::Api.new(connection).tap { |a| allow(a).to receive(:config).and_return(config) } }
-  let(:collection)          { api.job_templates }
-  let(:connection)          { AnsibleTowerClient::MockApi.new }
-  let(:config)              { {"version" => "2.1"} }
-  let(:raw_collection)      { build(:response_collection, :klass => described_class.base_class) }
-  let(:raw_url_collection)  { build(:response_url_collection, :klass => described_class.base_class, :url => url) }
-  let(:raw_instance)        { build(:response_instance, :job_template, :klass => described_class.base_class) }
+  let(:url)                        { "example.com/api/v1/job_templates" }
+  let(:api)                        { AnsibleTowerClient::Api.new(connection).tap { |a| allow(a).to receive(:config).and_return(config) } }
+  let(:connection)                 { AnsibleTowerClient::MockApi.new }
+  let(:config)                     { {"version" => "2.1"} }
+  let(:raw_instance)               { build(:response_instance, :job_template, :klass => described_class.base_class) }
   let(:raw_instance_no_extra_vars) { build(:response_instance, :job_template, :klass => described_class.base_class, :extra_vars => '') }
   let(:raw_instance_no_survey)     { build(:response_instance, :job_template, :klass => described_class.base_class, :related => {}) }
 
-  include_examples "Crud Methods"
   include_examples "Api Methods"
+  include_examples "Crud Methods"
+  include_examples "JobTemplate#extra_vars_hash"
   include_examples "JobTemplate#initialize"
   include_examples "JobTemplate#survey_spec"
   include_examples "JobTemplate#survey_spec_hash"
-  include_examples "JobTemplate#extra_vars_hash"
 
   describe '#launch' do
     let(:json) { {'extra_vars' => "{\"instance_ids\":[\"i-999c\"],\"state\":\"absent\",\"subnet_id\":\"subnet-887\"}"} }

--- a/spec/organization_spec.rb
+++ b/spec/organization_spec.rb
@@ -1,20 +1,16 @@
 describe AnsibleTowerClient::Organization do
-  let(:url)                 { "example.com/api/v1/organizations/13" }
-  let(:api)                 { AnsibleTowerClient::Api.new(instance_double("Faraday::Connection")) }
-  let(:collection)          { api.organizations }
-  let(:raw_collection)      { build(:response_collection, :klass => described_class) }
-  let(:raw_url_collection)  { build(:response_url_collection, :klass => described_class, :url => url) }
-  let(:raw_instance)        { build(:response_instance, :organization, :klass => described_class, :description => "The Organization", :name => "MyOrg") }
+  let(:api)          { AnsibleTowerClient::Api.new(AnsibleTowerClient::MockApi.new) }
+  let(:raw_instance) { build(:response_instance, :organization, :klass => described_class, :description => "The Organization", :name => "MyOrg") }
 
   include_examples "Crud Methods"
 
   it "#initialize instantiates an #{described_class} from a hash" do
-    obj = described_class.new(instance_double("AnsibleTowerClient::Api"), raw_instance)
+    obj = api.organizations.all.first
 
-    expect(obj).to              be_a described_class
-    expect(obj.id).to           be_a Integer
-    expect(obj.url).to          be_a String
-    expect(obj.description).to  eq "The Organization"
-    expect(obj.name).to         be_a String
+    expect(obj).to             be_a described_class
+    expect(obj.id).to          be_a Integer
+    expect(obj.url).to         be_a String
+    expect(obj.description).to eq "The Organization"
+    expect(obj.name).to        be_a String
   end
 end

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -9,12 +9,12 @@ describe AnsibleTowerClient::Project do
   it "#initialize instantiates an #{described_class} from a hash" do
     obj = api.projects.all.first
 
-    expect(obj).to              be_a described_class
-    expect(obj.id).to           be_a Integer
-    expect(obj.url).to          be_a String
-    expect(obj.organization).to be_a Integer
-    expect(obj.description).to  be_a String
-    expect(obj.name).to         be_a String
+    expect(obj).to                 be_a(described_class)
+    expect(obj.id).to              be_a(Integer)
+    expect(obj.url).to             be_a(String)
+    expect(obj.organization_id).to be_a(Integer)
+    expect(obj.description).to     be_a(String)
+    expect(obj.name).to            be_a(String)
   end
 
   describe '#can_update?' do

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -1,16 +1,13 @@
 describe AnsibleTowerClient::Project do
-  let(:url)                 { "example.com/api/v1/projects" }
-  let(:api)                 { AnsibleTowerClient::Api.new(instance_double("Faraday::Connection")) }
-  let(:collection)          { api.projects }
-  let(:raw_collection)      { build(:response_collection, :klass => described_class) }
-  let(:raw_url_collection)  { build(:response_url_collection, :klass => described_class, :url => url) }
-  let(:raw_instance)        { build(:response_instance, :project, :klass => described_class) }
+  let(:url)          { "example.com/api/v1/projects" }
+  let(:api)          { AnsibleTowerClient::Api.new(AnsibleTowerClient::MockApi.new) }
+  let(:raw_instance) { build(:response_instance, :project, :klass => described_class) }
 
-  include_examples "Crud Methods"
   include_examples "Api Methods"
+  include_examples "Crud Methods"
 
   it "#initialize instantiates an #{described_class} from a hash" do
-    obj = described_class.new(instance_double("AnsibleTowerClient::Api"), raw_instance)
+    obj = api.projects.all.first
 
     expect(obj).to              be_a described_class
     expect(obj.id).to           be_a Integer

--- a/spec/support/mock_api.rb
+++ b/spec/support/mock_api.rb
@@ -7,9 +7,11 @@ module AnsibleTowerClient
       end
     end
 
-    def get(path)
+    def get(path, get_options = nil)
       suffix = path.split("api/v1/").last
       case suffix
+      when "ad_hoc_commands"
+        wrap_response(AdHocCommand.response)
       when "config"
         wrap_response(Config.response)
       when "me"

--- a/spec/support/mock_api.rb
+++ b/spec/support/mock_api.rb
@@ -20,6 +20,8 @@ module AnsibleTowerClient
         wrap_response(Group.response)
       when "hosts"
         wrap_response(Host.response)
+      when "inventories"
+        wrap_response(Inventory.response)
       when "me"
         wrap_response(Me.response)
       end

--- a/spec/support/mock_api.rb
+++ b/spec/support/mock_api.rb
@@ -18,6 +18,8 @@ module AnsibleTowerClient
         wrap_response(Credential.response)
       when "groups"
         wrap_response(Group.response)
+      when "hosts"
+        wrap_response(Host.response)
       when "me"
         wrap_response(Me.response)
       end

--- a/spec/support/mock_api.rb
+++ b/spec/support/mock_api.rb
@@ -26,6 +26,8 @@ module AnsibleTowerClient
         wrap_response(Job.response)
       when "organizations"
         wrap_response(Organization.response)
+      when "projects"
+        wrap_response(Project.response)
       when "me"
         wrap_response(Me.response)
       end

--- a/spec/support/mock_api.rb
+++ b/spec/support/mock_api.rb
@@ -1,0 +1,24 @@
+module AnsibleTowerClient
+  class MockApi
+    class Response
+      attr_reader :body
+      def initialize(body)
+        @body = body
+      end
+    end
+
+    def get(path)
+      suffix = path.split("api/v1/").last
+      case suffix
+      when "config"
+        wrap_response(Config.response)
+      when "me"
+        wrap_response(Me.response)
+      end
+    end
+
+    def wrap_response(data)
+      AnsibleTowerClient::MockApi::Response.new(data)
+    end
+  end
+end

--- a/spec/support/mock_api.rb
+++ b/spec/support/mock_api.rb
@@ -28,6 +28,8 @@ module AnsibleTowerClient
         wrap_response(Inventory.response)
       when "jobs"
         wrap_response(Job.response)
+      when "job_templates"
+        wrap_response(JobTemplate.response)
       when "organizations"
         wrap_response(Organization.response)
       when "projects"

--- a/spec/support/mock_api.rb
+++ b/spec/support/mock_api.rb
@@ -16,6 +16,8 @@ module AnsibleTowerClient
         wrap_response(Config.response)
       when "credentials"
         wrap_response(Credential.response)
+      when "groups"
+        wrap_response(Group.response)
       when "me"
         wrap_response(Me.response)
       end

--- a/spec/support/mock_api.rb
+++ b/spec/support/mock_api.rb
@@ -22,6 +22,8 @@ module AnsibleTowerClient
         wrap_response(Host.response)
       when "inventories"
         wrap_response(Inventory.response)
+      when "jobs"
+        wrap_response(Job.response)
       when "me"
         wrap_response(Me.response)
       end

--- a/spec/support/mock_api.rb
+++ b/spec/support/mock_api.rb
@@ -14,6 +14,8 @@ module AnsibleTowerClient
         wrap_response(AdHocCommand.response)
       when "config"
         wrap_response(Config.response)
+      when "credentials"
+        wrap_response(Credential.response)
       when "me"
         wrap_response(Me.response)
       end

--- a/spec/support/mock_api.rb
+++ b/spec/support/mock_api.rb
@@ -24,6 +24,8 @@ module AnsibleTowerClient
         wrap_response(Inventory.response)
       when "jobs"
         wrap_response(Job.response)
+      when "organizations"
+        wrap_response(Organization.response)
       when "me"
         wrap_response(Me.response)
       end

--- a/spec/support/mock_api.rb
+++ b/spec/support/mock_api.rb
@@ -7,13 +7,17 @@ module AnsibleTowerClient
       end
     end
 
+    def initialize(version = nil)
+      @version = version
+    end
+
     def get(path, get_options = nil)
       suffix = path.split("api/v1/").last
       case suffix
       when "ad_hoc_commands"
         wrap_response(AdHocCommand.response)
       when "config"
-        wrap_response(Config.response)
+        wrap_response(Config.response(@version))
       when "credentials"
         wrap_response(Credential.response)
       when "groups"

--- a/spec/support/mock_api.rb
+++ b/spec/support/mock_api.rb
@@ -26,6 +26,8 @@ module AnsibleTowerClient
         wrap_response(Host.response)
       when "inventories"
         wrap_response(Inventory.response)
+      when "inventory_sources"
+        wrap_response(InventorySource.response)
       when "jobs"
         wrap_response(Job.response)
       when "job_templates"

--- a/spec/support/mock_api/ad_hoc_command.rb
+++ b/spec/support/mock_api/ad_hoc_command.rb
@@ -1,0 +1,79 @@
+module AnsibleTowerClient
+  class MockApi
+    module AdHocCommand
+      def self.collection
+        [
+          {
+            "id"              => 19,
+            "type"            => "ad_hoc_command",
+            "url"             => "/api/v1/ad_hoc_commands/19/",
+            "related"         => {
+              "created_by"      => "/api/v1/users/1/",
+              "stdout"          => "/api/v1/ad_hoc_commands/19/stdout/",
+              "inventory"       => "/api/v1/inventories/2/",
+              "credential"      => "/api/v1/credentials/6/",
+              "activity_stream" => "/api/v1/ad_hoc_commands/19/activity_stream/",
+              "events"          => "/api/v1/ad_hoc_commands/19/events/",
+              "cancel"          => "/api/v1/ad_hoc_commands/19/cancel/",
+              "relaunch"        => "/api/v1/ad_hoc_commands/19/relaunch/"
+            },
+            "summary_fields"  => {
+              "credential" => {
+                "name"        => "appliance",
+                "description" => "",
+                "kind"        => "ssh",
+                "cloud"       => false
+              },
+              "inventory"  => {
+                "name"                            => "AWS",
+                "description"                     => "AWS Lab",
+                "has_active_failures"             => true,
+                "total_hosts"                     => 29,
+                "hosts_with_active_failures"      => 29,
+                "total_groups"                    => 117,
+                "groups_with_active_failures"     => 110,
+                "has_inventory_sources"           => true,
+                "total_inventory_sources"         => 1,
+                "inventory_sources_with_failures" => 0
+              },
+              "created_by" => {
+                "id"         => 1,
+                "username"   => "admin",
+                "first_name" => "",
+                "last_name"  => ""
+              }
+            },
+            "created"         => "2016-01-15T21:07:32.411Z",
+            "modified"        => "2016-01-15T21:07:43.927Z",
+            "name"            => "ping",
+            "launch_type"     => "manual",
+            "status"          => "failed",
+            "failed"          => true,
+            "started"         => "2016-01-15T21:07:43.967Z",
+            "finished"        => "2016-01-15T21:07:57.978Z",
+            "elapsed"         => 14.011,
+            "job_explanation" => "",
+            "job_type"        => "run",
+            "inventory"       => 2,
+            "limit"           => "all",
+            "credential"      => 6,
+            "module_name"     => "ping",
+            "module_args"     => "",
+            "forks"           => 0,
+            "verbosity"       => 0,
+            "become_enabled"  => false
+          }.to_json
+        ]
+      end
+
+      def self.response
+        {
+          "count"    => collection.length,
+          "next"     => nil,
+          "previous" => nil,
+          "results"  => collection
+        }.to_json
+      end
+    end
+  end
+end

--- a/spec/support/mock_api/config.rb
+++ b/spec/support/mock_api/config.rb
@@ -1,0 +1,48 @@
+module AnsibleTowerClient
+  class MockApi
+    module Config
+      def self.response
+        {
+          "eula"                => "text",
+          "license_info"        => {
+            "deployment_id"          => "123abc",
+            "subscription_name"      => "Ansible Tower by Red Hat, Standard (10000 Managed Nodes)",
+            "current_instances"      => 100,
+            "features"               => {
+              "surveys"                => true,
+              "multiple_organizations" => true,
+              "system_tracking"        => true,
+              "enterprise_auth"        => true,
+              "rebranding"             => true,
+              "activity_streams"       => true,
+              "ldap"                   => true,
+              "ha"                     => true
+            },
+            "date_expired"           => false,
+            "available_instances"    => 10000,
+            "hostname"               => "123abc",
+            "free_instances"         => 9900,
+            "instance_count"         => 10000,
+            "time_remaining"         => 26167901,
+            "compliant"              => true,
+            "grace_period_remaining" => 28759901,
+            "contact_email"          => "someone@example.com",
+            "company_name"           => "Your Company, Inc.",
+            "date_warning"           => false,
+            "license_type"           => "enterprise",
+            "contact_name"           => "Someone",
+            "license_date"           => 1518710102,
+            "license_key"            => "123abc",
+            "valid_key"              => true
+          },
+          "analytics_status"    => "detailed",
+          "version"             => "3.0.1",
+          "project_base_dir"    => "/var/lib/awx/projects",
+          "time_zone"           => "America/New_York",
+          "ansible_version"     => "2.1.0.0",
+          "project_local_paths" => []
+        }.to_json
+      end
+    end
+  end
+end

--- a/spec/support/mock_api/config.rb
+++ b/spec/support/mock_api/config.rb
@@ -1,7 +1,7 @@
 module AnsibleTowerClient
   class MockApi
     module Config
-      def self.response
+      def self.response(version)
         {
           "eula"                => "text",
           "license_info"        => {
@@ -36,7 +36,7 @@ module AnsibleTowerClient
             "valid_key"              => true
           },
           "analytics_status"    => "detailed",
-          "version"             => "3.0.1",
+          "version"             => version || "3.0.1",
           "project_base_dir"    => "/var/lib/awx/projects",
           "time_zone"           => "America/New_York",
           "ansible_version"     => "2.1.0.0",

--- a/spec/support/mock_api/credential.rb
+++ b/spec/support/mock_api/credential.rb
@@ -1,0 +1,97 @@
+module AnsibleTowerClient
+  class MockApi
+    module Credential
+      def self.collection
+        [
+          {
+            "id"                 => 47,
+            "type"               => "credential",
+            "url"                => "/api/v1/credentials/47/",
+            "related"            => {
+              "created_by"      => "/api/v1/users/1/",
+              "modified_by"     => "/api/v1/users/1/",
+              "organization"    => "/api/v1/organizations/1/",
+              "owner_teams"     => "/api/v1/credentials/47/owner_teams/",
+              "owner_users"     => "/api/v1/credentials/47/owner_users/",
+              "activity_stream" => "/api/v1/credentials/47/activity_stream/",
+              "access_list"     => "/api/v1/credentials/47/access_list/",
+              "object_roles"    => "/api/v1/credentials/47/object_roles/"
+            },
+            "summary_fields"     => {
+              "host"         => {},
+              "project"      => {},
+              "organization" => {
+                "id"          => 1,
+                "name"        => "Default",
+                "description" => ""
+              },
+              "created_by"   => {
+                "id"         => 1,
+                "username"   => "admin",
+                "first_name" => "",
+                "last_name"  => ""
+              },
+              "modified_by"  => {
+                "id"         => 1,
+                "username"   => "admin",
+                "first_name" => "",
+                "last_name"  => ""
+              },
+              "object_roles" => {
+                "admin_role" => {
+                  "description" => "Can manage all aspects of the credential",
+                  "id"          => 1668,
+                  "name"        => "Admin"
+                },
+                "use_role"   => {
+                  "description" => "Can use the credential in a job template",
+                  "id"          => 1670,
+                  "name"        => "Use"
+                },
+                "read_role"  => {
+                  "description" => "May view settings for the credential",
+                  "id"          => 1669,
+                  "name"        => "Read"
+                }
+              },
+              "owners"       => []
+            },
+            "created"            => "2017-03-27T19:06:13.710Z",
+            "modified"           => "2017-03-27T19:13:51.406Z",
+            "name"               => "abc",
+            "description"        => "",
+            "kind"               => "aws",
+            "cloud"              => true,
+            "host"               => "",
+            "username"           => "a",
+            "password"           => "$encrypted$",
+            "security_token"     => "$encrypted$",
+            "project"            => "",
+            "domain"             => "",
+            "ssh_key_data"       => "",
+            "ssh_key_unlock"     => "",
+            "become_method"      => "",
+            "become_username"    => "",
+            "become_password"    => "",
+            "vault_password"     => "",
+            "subscription"       => "",
+            "tenant"             => "",
+            "secret"             => "",
+            "client"             => "",
+            "authorize"          => false,
+            "authorize_password" => ""
+          }
+        ]
+      end
+
+      def self.response
+        {
+          "count"    => collection.length,
+          "next"     => nil,
+          "previous" => nil,
+          "results"  => collection
+        }.to_json
+      end
+    end
+  end
+end

--- a/spec/support/mock_api/group.rb
+++ b/spec/support/mock_api/group.rb
@@ -1,0 +1,69 @@
+module AnsibleTowerClient
+  class MockApi
+    module Group
+      def self.collection
+        [
+          {
+            "id"                          => 9,
+            "type"                        => "group",
+            "url"                         => "/api/v1/groups/9/",
+            "related"                     => {
+              "job_host_summaries" => "/api/v1/groups/9/job_host_summaries/",
+              "variable_data"      => "/api/v1/groups/9/variable_data/",
+              "job_events"         => "/api/v1/groups/9/job_events/",
+              "potential_children" => "/api/v1/groups/9/potential_children/",
+              "ad_hoc_commands"    => "/api/v1/groups/9/ad_hoc_commands/",
+              "all_hosts"          => "/api/v1/groups/9/all_hosts/",
+              "activity_stream"    => "/api/v1/groups/9/activity_stream/",
+              "hosts"              => "/api/v1/groups/9/hosts/",
+              "children"           => "/api/v1/groups/9/children/",
+              "inventory_sources"  => "/api/v1/groups/9/inventory_sources/",
+              "inventory"          => "/api/v1/inventories/2/",
+              "inventory_source"   => "/api/v1/inventory_sources/14/"
+            },
+            "summary_fields"              => {
+              "inventory"        => {
+                "id"                              => 2,
+                "name"                            => "Dev-VC60",
+                "description"                     => "",
+                "has_active_failures"             => true,
+                "total_hosts"                     => 81,
+                "hosts_with_active_failures"      => 1,
+                "total_groups"                    => 24,
+                "groups_with_active_failures"     => 10,
+                "has_inventory_sources"           => true,
+                "total_inventory_sources"         => 2,
+                "inventory_sources_with_failures" => 2
+              },
+              "inventory_source" => {
+                "source" => "",
+                "status" => "ok"
+              }
+            },
+            "created"                     => "2016-08-31T16:59:39.628Z",
+            "modified"                    => "2017-03-02T04:14:05.306Z",
+            "name"                        => "centos64Guest",
+            "description"                 => "imported",
+            "inventory"                   => 2,
+            "variables"                   => "{}",
+            "has_active_failures"         => false,
+            "total_hosts"                 => 21,
+            "hosts_with_active_failures"  => 0,
+            "total_groups"                => 1,
+            "groups_with_active_failures" => 0,
+            "has_inventory_sources"       => true
+          }
+        ]
+      end
+
+      def self.response
+        {
+          "count"    => collection.length,
+          "next"     => nil,
+          "previous" => nil,
+          "results"  => collection
+        }.to_json
+      end
+    end
+  end
+end

--- a/spec/support/mock_api/host.rb
+++ b/spec/support/mock_api/host.rb
@@ -1,0 +1,95 @@
+module AnsibleTowerClient
+  class MockApi
+    module Host
+      def self.collection
+        [
+          {
+            "id"                    => 144,
+            "type"                  => "host",
+            "url"                   => "/api/v1/hosts/144/",
+            "related"               => {
+              "created_by"            => "/api/v1/users/1/",
+              "job_host_summaries"    => "/api/v1/hosts/144/job_host_summaries/",
+              "variable_data"         => "/api/v1/hosts/144/variable_data/",
+              "job_events"            => "/api/v1/hosts/144/job_events/",
+              "ad_hoc_commands"       => "/api/v1/hosts/144/ad_hoc_commands/",
+              "fact_versions"         => "/api/v1/hosts/144/fact_versions/",
+              "inventory_sources"     => "/api/v1/hosts/144/inventory_sources/",
+              "groups"                => "/api/v1/hosts/144/groups/",
+              "activity_stream"       => "/api/v1/hosts/144/activity_stream/",
+              "all_groups"            => "/api/v1/hosts/144/all_groups/",
+              "ad_hoc_command_events" => "/api/v1/hosts/144/ad_hoc_command_events/",
+              "inventory"             => "/api/v1/inventories/39/",
+              "last_job"              => "/api/v1/jobs/530/",
+              "last_job_host_summary" => "/api/v1/job_host_summaries/286/"
+            },
+            "summary_fields"        => {
+              "last_job"              => {
+                "id"                => 530,
+                "name"              => "Test_provision",
+                "description"       => "Test",
+                "finished"          => "2017-03-23T16:15:04.808Z",
+                "status"            => "failed",
+                "failed"            => true,
+                "job_template_id"   => 412,
+                "job_template_name" => "Test_provision"
+              },
+              "last_job_host_summary" => {
+                "id"     => 286,
+                "failed" => true
+              },
+              "inventory"             => {
+                "id"                              => 39,
+                "name"                            => "Test_provision_7",
+                "description"                     => "",
+                "has_active_failures"             => true,
+                "total_hosts"                     => 1,
+                "hosts_with_active_failures"      => 1,
+                "total_groups"                    => 0,
+                "groups_with_active_failures"     => 0,
+                "has_inventory_sources"           => false,
+                "total_inventory_sources"         => 0,
+                "inventory_sources_with_failures" => 0
+              },
+              "created_by"            => {
+                "id"         => 1,
+                "username"   => "admin",
+                "first_name" => "",
+                "last_name"  => ""
+              },
+              "recent_jobs"           => [
+                {
+                  "status"   => "failed",
+                  "finished" => "2017-03-23T16:15:04.808Z",
+                  "id"       => 530,
+                  "name"     => "Test_provision"
+                }
+              ]
+            },
+            "created"               => "2017-03-23T16:14:44.524Z",
+            "modified"              => "2017-03-23T16:15:04.717Z",
+            "name"                  => "10.0.1.78",
+            "description"           => "",
+            "inventory"             => 39,
+            "enabled"               => true,
+            "instance_id"           => "",
+            "variables"             => "",
+            "has_active_failures"   => true,
+            "has_inventory_sources" => false,
+            "last_job"              => 530,
+            "last_job_host_summary" => 286
+          }
+        ]
+      end
+
+      def self.response
+        {
+          "count"    => collection.length,
+          "next"     => nil,
+          "previous" => nil,
+          "results"  => collection
+        }.to_json
+      end
+    end
+  end
+end

--- a/spec/support/mock_api/inventory.rb
+++ b/spec/support/mock_api/inventory.rb
@@ -1,0 +1,95 @@
+module AnsibleTowerClient
+  class MockApi
+    module Inventory
+      def self.collection
+        [
+          {
+            "id"                              => 6,
+            "type"                            => "inventory",
+            "url"                             => "/api/v1/inventories/6/",
+            "related"                         => {
+              "created_by"         => "/api/v1/users/1/",
+              "job_templates"      => "/api/v1/inventories/6/job_templates/",
+              "scan_job_templates" => "/api/v1/inventories/6/scan_job_templates/",
+              "variable_data"      => "/api/v1/inventories/6/variable_data/",
+              "root_groups"        => "/api/v1/inventories/6/root_groups/",
+              "object_roles"       => "/api/v1/inventories/6/object_roles/",
+              "ad_hoc_commands"    => "/api/v1/inventories/6/ad_hoc_commands/",
+              "script"             => "/api/v1/inventories/6/script/",
+              "tree"               => "/api/v1/inventories/6/tree/",
+              "access_list"        => "/api/v1/inventories/6/access_list/",
+              "hosts"              => "/api/v1/inventories/6/hosts/",
+              "groups"             => "/api/v1/inventories/6/groups/",
+              "activity_stream"    => "/api/v1/inventories/6/activity_stream/",
+              "inventory_sources"  => "/api/v1/inventories/6/inventory_sources/",
+              "organization"       => "/api/v1/organizations/3/"
+            },
+            "summary_fields"                  => {
+              "organization" => {
+                "id"          => 3,
+                "name"        => "ACME Corp",
+                "description" => "Which belongs to goern"
+              },
+              "created_by"   => {
+                "id"         => 1,
+                "username"   => "admin",
+                "first_name" => "",
+                "last_name"  => ""
+              },
+              "object_roles" => {
+                "use_role"    => {
+                  "description" => "Can use the inventory in a job template",
+                  "id"          => 110,
+                  "name"        => "Use"
+                },
+                "admin_role"  => {
+                  "description" => "Can manage all aspects of the inventory",
+                  "id"          => 108,
+                  "name"        => "Admin"
+                },
+                "adhoc_role"  => {
+                  "description" => "May run ad hoc commands on an inventory",
+                  "id"          => 107,
+                  "name"        => "Ad Hoc"
+                },
+                "update_role" => {
+                  "description" => "May update project or inventory or group using the configured source update system",
+                  "id"          => 111,
+                  "name"        => "Update"
+                },
+                "read_role"   => {
+                  "description" => "May view settings for the inventory",
+                  "id"          => 109,
+                  "name"        => "Read"
+                }
+              }
+            },
+            "created"                         => "2017-01-30T10:53:48.130Z",
+            "modified"                        => "2017-02-23T17:43:39.928Z",
+            "name"                            => "acme-corp",
+            "description"                     => "",
+            "organization"                    => 3,
+            "variables"                       => "---\nOCP_URL: https://acme-ocp3-haproxy-0.acme.e2e.example.com:8443\nOCP_MASTER: acme-ocp3-haproxy-0.acme.e2e.example.com\nOCP_USER: pltops\n\nOCP_PROJECT: coolstore-dev\nARTIFACTORY_API_URL: http://acme-dev-infra-artifactory.acme.e2e.example.com:8081/artifactory/api/",
+            "has_active_failures"             => true,
+            "total_hosts"                     => 1,
+            "hosts_with_active_failures"      => 1,
+            "total_groups"                    => 2,
+            "groups_with_active_failures"     => 1,
+            "has_inventory_sources"           => true,
+            "total_inventory_sources"         => 1,
+            "inventory_sources_with_failures" => 1
+          }
+        ]
+      end
+
+      def self.response
+        {
+          "count"    => collection.length,
+          "next"     => nil,
+          "previous" => nil,
+          "results"  => collection
+        }.to_json
+      end
+    end
+  end
+end

--- a/spec/support/mock_api/inventory_source.rb
+++ b/spec/support/mock_api/inventory_source.rb
@@ -1,0 +1,122 @@
+module AnsibleTowerClient
+  class MockApi
+    module InventorySource
+      def self.collection
+        [
+          {
+            "id"                   => 6,
+            "type"                 => "inventory_source",
+            "url"                  => "/api/v1/inventory_sources/6/",
+            "related"              => {
+              "created_by"                     => "/api/v1/users/1/",
+              "credential"                     => "/api/v1/credentials/2/",
+              "last_job"                       => "/api/v1/inventory_updates/199/",
+              "notification_templates_error"   => "/api/v1/inventory_sources/6/notification_templates_error/",
+              "notification_templates_success" => "/api/v1/inventory_sources/6/notification_templates_success/",
+              "notification_templates_any"     => "/api/v1/inventory_sources/6/notification_templates_any/",
+              "inventory_updates"              => "/api/v1/inventory_sources/6/inventory_updates/",
+              "update"                         => "/api/v1/inventory_sources/6/update/",
+              "hosts"                          => "/api/v1/inventory_sources/6/hosts/",
+              "groups"                         => "/api/v1/inventory_sources/6/groups/",
+              "schedules"                      => "/api/v1/inventory_sources/6/schedules/",
+              "activity_stream"                => "/api/v1/inventories/6/activity_stream/",
+              "inventory"                      => "/api/v1/inventories/2/",
+              "group"                          => "/api/v1/groups/1/",
+              "last_update"                    => "/api/v1/inventory_updates/199/"
+            },
+            "summary_fields"       => {
+              "last_job"    => {
+                "id"            => 199,
+                "name"          => "dev-vc60 (Dev-VC60)",
+                "description"   => "",
+                "finished"      => "2017-02-20T21:56:21.910Z",
+                "status"        => "failed",
+                "failed"        => true,
+                "license_error" => false
+              },
+              "group"       => {
+                "id"                          => 1,
+                "name"                        => "dev-vc60",
+                "description"                 => "",
+                "has_active_failures"         => true,
+                "total_hosts"                 => 81,
+                "hosts_with_active_failures"  => 1,
+                "total_groups"                => 23,
+                "groups_with_active_failures" => 9,
+                "has_inventory_sources"       => true
+              },
+              "last_update" => {
+                "id"            => 199,
+                "name"          => "dev-vc60 (Dev-VC60)",
+                "description"   => "",
+                "status"        => "failed",
+                "failed"        => true,
+                "license_error" => false
+              },
+              "inventory"   => {
+                "id"                              => 2,
+                "name"                            => "Dev-VC60",
+                "description"                     => "",
+                "has_active_failures"             => true,
+                "total_hosts"                     => 81,
+                "hosts_with_active_failures"      => 1,
+                "total_groups"                    => 24,
+                "groups_with_active_failures"     => 10,
+                "has_inventory_sources"           => true,
+                "total_inventory_sources"         => 2,
+                "inventory_sources_with_failures" => 2
+              },
+              "credential"  => {
+                "id"          => 2,
+                "name"        => "dev-vc60",
+                "description" => "",
+                "kind"        => "vmware",
+                "cloud"       => true
+              },
+              "created_by"  => {
+                "id"         => 1,
+                "username"   => "admin",
+                "first_name" => "",
+                "last_name"  => ""
+              }
+            },
+            "created"              => "2016-08-30T22:44:01.626Z",
+            "modified"             => "2016-08-31T16:59:11.977Z",
+            "name"                 => "dev-vc60 (Dev-VC60 - 6)",
+            "description"          => "",
+            "source"               => "vmware",
+            "source_path"          => "",
+            "source_script"        => nil,
+            "source_vars"          => "",
+            "credential"           => 2,
+            "source_regions"       => "",
+            "instance_filters"     => "",
+            "group_by"             => "",
+            "overwrite"            => false,
+            "overwrite_vars"       => false,
+            "last_job_run"         => "2017-02-20T21:56:21.910046Z",
+            "last_job_failed"      => true,
+            "has_schedules"        => false,
+            "next_job_run"         => nil,
+            "status"               => "failed",
+            "inventory"            => 2,
+            "group"                => 1,
+            "update_on_launch"     => false,
+            "update_cache_timeout" => 0,
+            "last_update_failed"   => true,
+            "last_updated"         => "2017-02-20T21:56:21.910046Z"
+          }
+        ]
+      end
+
+      def self.response
+        {
+          "count"    => collection.length,
+          "next"     => nil,
+          "previous" => nil,
+          "results"  => collection
+        }.to_json
+      end
+    end
+  end
+end

--- a/spec/support/mock_api/job.rb
+++ b/spec/support/mock_api/job.rb
@@ -1,0 +1,127 @@
+module AnsibleTowerClient
+  class MockApi
+    module Job
+      def self.collection
+        [
+          {
+            "id"                        => 103,
+            "type"                      => "job",
+            "url"                       => "/api/v1/jobs/103/",
+            "related"                   => {
+              "created_by"           => "/api/v1/users/1/",
+              "labels"               => "/api/v1/jobs/103/labels/",
+              "inventory"            => "/api/v1/inventories/1/",
+              "project"              => "/api/v1/projects/4/",
+              "credential"           => "/api/v1/credentials/1/",
+              "unified_job_template" => "/api/v1/job_templates/30/",
+              "stdout"               => "/api/v1/jobs/103/stdout/",
+              "job_host_summaries"   => "/api/v1/jobs/103/job_host_summaries/",
+              "job_tasks"            => "/api/v1/jobs/103/job_tasks/",
+              "job_plays"            => "/api/v1/jobs/103/job_plays/",
+              "job_events"           => "/api/v1/jobs/103/job_events/",
+              "notifications"        => "/api/v1/jobs/103/notifications/",
+              "activity_stream"      => "/api/v1/jobs/103/activity_stream/",
+              "job_template"         => "/api/v1/job_templates/30/",
+              "start"                => "/api/v1/jobs/103/start/",
+              "cancel"               => "/api/v1/jobs/103/cancel/",
+              "relaunch"             => "/api/v1/jobs/103/relaunch/"
+            },
+            "summary_fields"            => {
+              "job_template"         => {
+                "id"          => 30,
+                "name"        => "bd-test",
+                "description" => ""
+              },
+              "inventory"            => {
+                "id"                              => 1,
+                "name"                            => "Demo Inventory",
+                "description"                     => "",
+                "has_active_failures"             => false,
+                "total_hosts"                     => 2,
+                "hosts_with_active_failures"      => 0,
+                "total_groups"                    => 0,
+                "groups_with_active_failures"     => 0,
+                "has_inventory_sources"           => false,
+                "total_inventory_sources"         => 0,
+                "inventory_sources_with_failures" => 0
+              },
+              "credential"           => {
+                "id"          => 1,
+                "name"        => "Demo Credential",
+                "description" => "",
+                "kind"        => "ssh",
+                "cloud"       => false
+              },
+              "unified_job_template" => {
+                "id"               => 30,
+                "name"             => "bd-test",
+                "description"      => "",
+                "unified_job_type" => "job"
+              },
+              "project"              => {
+                "id"          => 4,
+                "name"        => "Demo Project",
+                "description" => "A great demo",
+                "status"      => "successful"
+              },
+              "created_by"           => {
+                "id"         => 1,
+                "username"   => "admin",
+                "first_name" => "",
+                "last_name"  => ""
+              },
+              "labels"               => {
+                "count"   => 0,
+                "results" => []
+              }
+            },
+            "created"                   => "2017-02-06T15:06:53.338Z",
+            "modified"                  => "2017-02-06T15:07:03.883Z",
+            "name"                      => "bd-test",
+            "description"               => "",
+            "unified_job_template"      => 30,
+            "launch_type"               => "manual",
+            "status"                    => "successful",
+            "failed"                    => false,
+            "started"                   => "2017-02-06T15:07:16.022594Z",
+            "finished"                  => "2017-02-06T15:07:19.588779Z",
+            "elapsed"                   => 3.566,
+            "job_explanation"           => "",
+            "job_type"                  => "run",
+            "inventory"                 => 1,
+            "project"                   => 4,
+            "playbook"                  => "hello_world.yml",
+            "credential"                => 1,
+            "cloud_credential"          => nil,
+            "network_credential"        => nil,
+            "forks"                     => 0,
+            "limit"                     => "",
+            "verbosity"                 => 0,
+            "extra_vars"                => "{}",
+            "job_tags"                  => "",
+            "force_handlers"            => false,
+            "skip_tags"                 => "",
+            "start_at_task"             => "",
+            "job_template"              => 30,
+            "passwords_needed_to_start" => [],
+            "ask_variables_on_launch"   => false,
+            "ask_limit_on_launch"       => false,
+            "ask_tags_on_launch"        => false,
+            "ask_job_type_on_launch"    => false,
+            "ask_inventory_on_launch"   => false,
+            "ask_credential_on_launch"  => false
+          }
+        ]
+      end
+
+      def self.response
+        {
+          "count"    => collection.length,
+          "next"     => nil,
+          "previous" => nil,
+          "results"  => collection
+        }.to_json
+      end
+    end
+  end
+end

--- a/spec/support/mock_api/job_template.rb
+++ b/spec/support/mock_api/job_template.rb
@@ -1,0 +1,175 @@
+module AnsibleTowerClient
+  class MockApi
+    module JobTemplate
+      def self.collection
+        [
+          {
+            "id"                       => 108,
+            "type"                     => "job_template",
+            "url"                      => "/api/v1/job_templates/108/",
+            "related"                  => {
+              "created_by"                     => "/api/v1/users/1/",
+              "labels"                         => "/api/v1/job_templates/108/labels/",
+              "inventory"                      => "/api/v1/inventories/8/",
+              "project"                        => "/api/v1/projects/37/",
+              "credential"                     => "/api/v1/credentials/1/",
+              "last_job"                       => "/api/v1/jobs/140/",
+              "notification_templates_error"   => "/api/v1/job_templates/108/notification_templates_error/",
+              "notification_templates_success" => "/api/v1/job_templates/108/notification_templates_success/",
+              "jobs"                           => "/api/v1/job_templates/108/jobs/",
+              "object_roles"                   => "/api/v1/job_templates/108/object_roles/",
+              "notification_templates_any"     => "/api/v1/job_templates/108/notification_templates_any/",
+              "access_list"                    => "/api/v1/job_templates/108/access_list/",
+              "launch"                         => "/api/v1/job_templates/108/launch/",
+              "schedules"                      => "/api/v1/job_templates/108/schedules/",
+              "activity_stream"                => "/api/v1/job_templates/108/activity_stream/",
+              "survey_spec"                    => "/api/v1/job_templates/108/survey_spec/"
+            },
+            "summary_fields"           => {
+              "last_job"     => {
+                "id"          => 140,
+                "name"        => "421_playbook-service-demo_provision",
+                "description" => "this is a test",
+                "finished"    => "2017-02-16T21:45:28.115Z",
+                "status"      => "successful",
+                "failed"      => false
+              },
+              "last_update"  => {
+                "id"          => 140,
+                "name"        => "421_playbook-service-demo_provision",
+                "description" => "this is a test",
+                "status"      => "successful",
+                "failed"      => false
+              },
+              "inventory"    => {
+                "id"                              => 8,
+                "name"                            => "miq-default",
+                "description"                     => "default inventory",
+                "has_active_failures"             => false,
+                "total_hosts"                     => 2,
+                "hosts_with_active_failures"      => 0,
+                "total_groups"                    => 0,
+                "groups_with_active_failures"     => 0,
+                "has_inventory_sources"           => false,
+                "total_inventory_sources"         => 0,
+                "inventory_sources_with_failures" => 0
+              },
+              "credential"   => {
+                "id"          => 1,
+                "name"        => "Demo Credential",
+                "description" => "",
+                "kind"        => "ssh",
+                "cloud"       => false
+              },
+              "project"      => {
+                "id"          => 37,
+                "name"        => "Test Project",
+                "description" => "",
+                "status"      => "successful"
+              },
+              "created_by"   => {
+                "id"         => 1,
+                "username"   => "admin",
+                "first_name" => "",
+                "last_name"  => ""
+              },
+              "object_roles" => {
+                "admin_role"   => {
+                  "description" => "Can manage all aspects of the job template",
+                  "id"          => 325,
+                  "name"        => "Admin"
+                },
+                "execute_role" => {
+                  "description" => "May run the job template",
+                  "id"          => 327,
+                  "name"        => "Execute"
+                },
+                "read_role"    => {
+                  "description" => "May view settings for the job template",
+                  "id"          => 326,
+                  "name"        => "Read"
+                }
+              },
+              "labels"       => {
+                "count"   => 0,
+                "results" => []
+              },
+              "can_copy"     => true,
+              "can_edit"     => true,
+              "recent_jobs"  => [
+                {
+                  "status"   => "successful",
+                  "finished" => "2017-02-16T21:45:28.115Z",
+                  "id"       => 140
+                },
+                {
+                  "status"   => "failed",
+                  "finished" => "2017-02-16T21:23:55.950Z",
+                  "id"       => 138
+                },
+                {
+                  "status"   => "successful",
+                  "finished" => "2017-02-16T21:20:20.336Z",
+                  "id"       => 136
+                },
+                {
+                  "status"   => "failed",
+                  "finished" => "2017-02-16T21:14:39.976Z",
+                  "id"       => 133
+                },
+                {
+                  "status"   => "successful",
+                  "finished" => "2017-02-11T18:29:47.257Z",
+                  "id"       => 110
+                }
+              ]
+            },
+            "created"                  => "2017-02-11T18:13:49.720Z",
+            "modified"                 => "2017-02-16T21:45:12.197Z",
+            "name"                     => "421_playbook-service-demo_provision",
+            "description"              => "this is a test",
+            "job_type"                 => "run",
+            "inventory"                => 8,
+            "project"                  => 37,
+            "playbook"                 => "hello_world.yml",
+            "credential"               => 1,
+            "cloud_credential"         => nil,
+            "network_credential"       => nil,
+            "forks"                    => 0,
+            "limit"                    => "",
+            "verbosity"                => 3,
+            "extra_vars"               => {"option" => "lots_of_options"}.to_json,
+            "job_tags"                 => "",
+            "force_handlers"           => false,
+            "skip_tags"                => "",
+            "start_at_task"            => "",
+            "last_job_run"             => "2017-02-16T21:45:28.115918Z",
+            "last_job_failed"          => false,
+            "has_schedules"            => false,
+            "next_job_run"             => nil,
+            "status"                   => "successful",
+            "host_config_key"          => "",
+            "ask_variables_on_launch"  => true,
+            "ask_limit_on_launch"      => true,
+            "ask_tags_on_launch"       => false,
+            "ask_job_type_on_launch"   => false,
+            "ask_inventory_on_launch"  => true,
+            "ask_credential_on_launch" => true,
+            "survey_enabled"           => false,
+            "become_enabled"           => false,
+            "allow_simultaneous"       => false
+          }
+        ]
+      end
+
+      def self.response
+        {
+          "count"    => collection.length,
+          "next"     => nil,
+          "previous" => nil,
+          "results"  => collection
+        }.to_json
+      end
+    end
+  end
+end

--- a/spec/support/mock_api/me.rb
+++ b/spec/support/mock_api/me.rb
@@ -1,0 +1,44 @@
+module AnsibleTowerClient
+  class MockApi
+    module Me
+      def self.collection
+        [
+          {
+            "id"                => 1,
+            "type"              => "user",
+            "url"               => "/api/v1/users/1/",
+            "related"           => {
+              "admin_of_organizations" => "/api/v1/users/1/admin_of_organizations/",
+              "organizations"          => "/api/v1/users/1/organizations/",
+              "roles"                  => "/api/v1/users/1/roles/",
+              "access_list"            => "/api/v1/users/1/access_list/",
+              "teams"                  => "/api/v1/users/1/teams/",
+              "credentials"            => "/api/v1/users/1/credentials/",
+              "activity_stream"        => "/api/v1/users/1/activity_stream/",
+              "projects"               => "/api/v1/users/1/projects/"
+            },
+            "created"           => "2016-08-02T17:56:37.162Z",
+            "username"          => "admin",
+            "first_name"        => "",
+            "last_name"         => "",
+            "email"             => "admin@example.com",
+            "is_superuser"      => true,
+            "is_system_auditor" => false,
+            "ldap_dn"           => "",
+            "external_account"  => nil,
+            "auth"              => []
+          }
+        ]
+      end
+
+      def self.response
+        {
+          "count"    => collection.length,
+          "next"     => nil,
+          "previous" => nil,
+          "results"  => collection
+        }.to_json
+      end
+    end
+  end
+end

--- a/spec/support/mock_api/organization.rb
+++ b/spec/support/mock_api/organization.rb
@@ -1,0 +1,89 @@
+module AnsibleTowerClient
+  class MockApi
+    module Organization
+      def self.collection
+        [
+          {
+            "id"             => 3,
+            "type"           => "organization",
+            "url"            => "/api/v1/organizations/3/",
+            "related"        => {
+              "created_by"                     => "/api/v1/users/1/",
+              "modified_by"                    => "/api/v1/users/1/",
+              "notification_templates_error"   => "/api/v1/organizations/3/notification_templates_error/",
+              "notification_templates_success" => "/api/v1/organizations/3/notification_templates_success/",
+              "users"                          => "/api/v1/organizations/3/users/",
+              "object_roles"                   => "/api/v1/organizations/3/object_roles/",
+              "notification_templates_any"     => "/api/v1/organizations/3/notification_templates_any/",
+              "teams"                          => "/api/v1/organizations/3/teams/",
+              "access_list"                    => "/api/v1/organizations/3/access_list/",
+              "notification_templates"         => "/api/v1/organizations/3/notification_templates/",
+              "admins"                         => "/api/v1/organizations/3/admins/",
+              "credentials"                    => "/api/v1/organizations/3/credentials/",
+              "inventories"                    => "/api/v1/organizations/3/inventories/",
+              "activity_stream"                => "/api/v1/organizations/3/activity_stream/",
+              "projects"                       => "/api/v1/organizations/3/projects/"
+            },
+            "summary_fields" => {
+              "created_by"           => {
+                "id"         => 1,
+                "username"   => "admin",
+                "first_name" => "",
+                "last_name"  => ""
+              },
+              "modified_by"          => {
+                "id"         => 1,
+                "username"   => "admin",
+                "first_name" => "",
+                "last_name"  => ""
+              },
+              "object_roles"         => {
+                "auditor_role" => {
+                  "description" => "Can view all settings for the organization",
+                  "id"          => 106,
+                  "name"        => "Auditor"
+                },
+                "admin_role"   => {
+                  "description" => "Can manage all aspects of the organization",
+                  "id"          => 105,
+                  "name"        => "Admin"
+                },
+                "member_role"  => {
+                  "description" => "User is a member of the organization",
+                  "id"          => 104,
+                  "name"        => "Member"
+                },
+                "read_role"    => {
+                  "description" => "May view settings for the organization",
+                  "id"          => 103,
+                  "name"        => "Read"
+                }
+              },
+              "related_field_counts" => {
+                "job_templates" => 3,
+                "users"         => 1,
+                "teams"         => 0,
+                "admins"        => 0,
+                "inventories"   => 2,
+                "projects"      => 1
+              }
+            },
+            "created"        => "2017-01-30T10:48:57.692Z",
+            "modified"       => "2017-01-30T10:48:57.692Z",
+            "name"           => "ACME Corp",
+            "description"    => "The Organization"
+          }
+        ]
+      end
+
+      def self.response
+        {
+          "count"    => collection.length,
+          "next"     => nil,
+          "previous" => nil,
+          "results"  => collection
+        }.to_json
+      end
+    end
+  end
+end

--- a/spec/support/mock_api/project.rb
+++ b/spec/support/mock_api/project.rb
@@ -1,0 +1,113 @@
+module AnsibleTowerClient
+  class MockApi
+    module Project
+      def self.collection
+        [
+          {
+            "id"                        => 4,
+            "type"                      => "project",
+            "url"                       => "/api/v1/projects/4/",
+            "related"                   => {
+              "created_by"                     => "/api/v1/users/1/",
+              "last_job"                       => "/api/v1/project_updates/623/",
+              "notification_templates_error"   => "/api/v1/projects/4/notification_templates_error/",
+              "notification_templates_success" => "/api/v1/projects/4/notification_templates_success/",
+              "object_roles"                   => "/api/v1/projects/4/object_roles/",
+              "notification_templates_any"     => "/api/v1/projects/4/notification_templates_any/",
+              "project_updates"                => "/api/v1/projects/4/project_updates/",
+              "update"                         => "/api/v1/projects/4/update/",
+              "access_list"                    => "/api/v1/projects/4/access_list/",
+              "playbooks"                      => "/api/v1/projects/4/playbooks/",
+              "schedules"                      => "/api/v1/projects/4/schedules/",
+              "teams"                          => "/api/v1/projects/4/teams/",
+              "activity_stream"                => "/api/v1/projects/4/activity_stream/",
+              "organization"                   => "/api/v1/organizations/1/",
+              "last_update"                    => "/api/v1/project_updates/623/"
+            },
+            "summary_fields"            => {
+              "last_job"     => {
+                "id"          => 623,
+                "name"        => "Demo Project",
+                "description" => "A great demo",
+                "finished"    => "2017-04-10T08:32:56.496Z",
+                "status"      => "successful",
+                "failed"      => false
+              },
+              "last_update"  => {
+                "id"          => 623,
+                "name"        => "Demo Project",
+                "description" => "A great demo",
+                "status"      => "successful",
+                "failed"      => false
+              },
+              "organization" => {
+                "id"          => 1,
+                "name"        => "Default",
+                "description" => ""
+              },
+              "created_by"   => {
+                "id"         => 1,
+                "username"   => "admin",
+                "first_name" => "",
+                "last_name"  => ""
+              },
+              "object_roles" => {
+                "admin_role"  => {
+                  "description" => "Can manage all aspects of the project",
+                  "id"          => 8,
+                  "name"        => "Admin"
+                },
+                "use_role"    => {
+                  "description" => "Can use the project in a job template",
+                  "id"          => 10,
+                  "name"        => "Use"
+                },
+                "update_role" => {
+                  "description" => "May update project or inventory or group using the configured source update system",
+                  "id"          => 11,
+                  "name"        => "Update"
+                },
+                "read_role"   => {
+                  "description" => "May view settings for the project",
+                  "id"          => 9,
+                  "name"        => "Read"
+                }
+              }
+            },
+            "created"                   => "2016-08-02T17:57:02.914Z",
+            "modified"                  => "2017-04-04T07:14:51.147Z",
+            "name"                      => "Demo Project",
+            "description"               => "A great demo",
+            "local_path"                => "_4__demo_project",
+            "scm_type"                  => "git",
+            "scm_url"                   => "https://github.com/ansible/ansible-tower-samples",
+            "scm_branch"                => "master",
+            "scm_clean"                 => true,
+            "scm_delete_on_update"      => false,
+            "credential"                => nil,
+            "last_job_run"              => "2017-04-10T08:32:56.496316Z",
+            "last_job_failed"           => false,
+            "has_schedules"             => false,
+            "next_job_run"              => nil,
+            "status"                    => "successful",
+            "organization"              => 1,
+            "scm_delete_on_next_update" => false,
+            "scm_update_on_launch"      => false,
+            "scm_update_cache_timeout"  => 0,
+            "last_update_failed"        => false,
+            "last_updated"              => "2017-04-10T08:32:56.496316Z"
+          }
+        ]
+      end
+
+      def self.response
+        {
+          "count"    => collection.length,
+          "next"     => nil,
+          "previous" => nil,
+          "results"  => collection
+        }.to_json
+      end
+    end
+  end
+end

--- a/spec/support/shared_examples/job_template.rb
+++ b/spec/support/shared_examples/job_template.rb
@@ -1,13 +1,13 @@
 shared_examples_for "JobTemplate#initialize" do
   it "#initialize instantiates an #{described_class} from a hash" do
-    obj = described_class.new(instance_double("AnsibleTowerClient::Api"), raw_instance)
+    obj = api.job_templates.all.first
 
     expect(obj).to             be_a described_class
     expect(obj.id).to          be_a Integer
     expect(obj.name).to        be_a String
     expect(obj.description).to be_a String
     expect(obj.related).to     be_a described_class::Related
-    expect(obj.extra_vars).to  eq("{\"option\":\"lots of options\"}")
+    expect(obj.extra_vars).to  eq("{\"option\":\"lots_of_options\"}")
   end
 end
 


### PR DESCRIPTION
@syncrou I think it's about time we start testing with real data.  There's more coming, but in this PR I covered the root collection classes.

I know there is some duplication and the `get` method needs to be smarter, but I wanted to keep this relatively small so it isn't impossible to review.  Let me know what you think.

I even found and fixed a bug in a spec which proves that the previous mocking wasn't adding much value for the `#initialize` tests.