### PR TITLE
Check before update attribute of basemodel

### DIFF
--- a/lib/ansible_tower_client/base_model.rb
+++ b/lib/ansible_tower_client/base_model.rb
@@ -82,10 +82,11 @@ module AnsibleTowerClient
     def update_attributes!(attributes)
       @api.patch(url, attributes.to_json)
       attributes.each do |method_name, value|
-        if override_raw_attributes[method_name]
-          send("#{override_raw_attributes[method_name]}=", value)
+        invoke_name = "#{override_raw_attributes[method_name] || method_name}="
+        if respond_to?(invoke_name)
+          send(invoke_name, value)
         else
-          send("#{method_name}=", value)
+          AnsibleTowerClient.logger.warn("Unknown attribute/method: #{invoke_name}. Skip updating it ...")
         end
       end
       true

--- a/spec/support/shared_examples/crud_methods.rb
+++ b/spec/support/shared_examples/crud_methods.rb
@@ -37,6 +37,12 @@ shared_examples_for "Crud Methods" do
         expect(obj.name).to eq 'blah'
       end
 
+      it "ignore unknown attributes if patch succeeds" do
+        expect(instance_api).to receive(:patch).and_return(instance_double("Faraday::Result", :body => raw_instance.to_json))
+        expect(obj.update_attributes!(:name => 'blah', :stranger_thing => 'bomb')).to eq true
+        expect(obj.name).to eq 'blah'
+      end
+
       it "returns an error if an error is raised" do
         expect(instance_api).to receive(:patch).and_raise(AnsibleTowerClient::Error, 'error')
         expect { obj.update_attributes!(:name => 'bad name') }.to raise_error(AnsibleTowerClient::Error)


### PR DESCRIPTION
This is to fix https://bugzilla.redhat.com/show_bug.cgi?id=1445995

When caller passes in attributes that client doesn't know, even though Tower succeed in the call, client is blown up.

@miq-bot add_labels wip, bug