### PR TITLE
Revert "Upgrade Faraday to minimum of v0.13 for IPv6 support"

### DIFF
--- a/ansible_tower_client.gemspec
+++ b/ansible_tower_client.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "activesupport"
-  spec.add_runtime_dependency "faraday",              "~> 0.13"
+  spec.add_runtime_dependency "faraday"
   spec.add_runtime_dependency "faraday_middleware"
   spec.add_runtime_dependency "more_core_extensions", "~> 3.0"
 


### PR DESCRIPTION
This reverts commit 7e82aa8bee9bab0d4a8ca0f58cb5c4a38f95773d.

Reverting until the rest of ManageIQ is able to upgrade. cc @carbonin 