### PR TITLE
Add project last update stdout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Fix debug logging of non-JSON responses [(#102)](https://github.com/ansible/ansible_tower_client_ruby/pull/102)
 
 ## [0.13.0] - 2018-04-05
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- Add Project#last_update [(#102)](https://github.com/ansible/ansible_tower_client_ruby/pull/102)
+
 ### Fixed
 - Fix debug logging of non-JSON responses [(#102)](https://github.com/ansible/ansible_tower_client_ruby/pull/102)
 

--- a/lib/ansible_tower_client/api.rb
+++ b/lib/ansible_tower_client/api.rb
@@ -96,6 +96,7 @@ module AnsibleTowerClient
     end
 
     def method_missing(method_name, *args, &block)
+      require 'faraday'
       if instance.respond_to?(method_name)
         path = build_path_to_resource(args.shift)
         args.unshift(path)

--- a/lib/ansible_tower_client/api.rb
+++ b/lib/ansible_tower_client/api.rb
@@ -102,7 +102,7 @@ module AnsibleTowerClient
         args.unshift(path)
         logger.debug { "#{self.class.name} Sending <#{method_name}> with <#{args.inspect}>" }
         instance.send(method_name, *args, &block).tap do |response|
-          logger.debug { "#{self.class.name} Response:\n#{JSON.parse(response.body).pretty_inspect}" }
+          logger.debug { "#{self.class.name} Response:\n#{log_from_response(response)}" }
         end
       else
         super

--- a/lib/ansible_tower_client/base_models/project.rb
+++ b/lib/ansible_tower_client/base_models/project.rb
@@ -17,5 +17,10 @@ module AnsibleTowerClient
 
       api.project_updates.find(update['project_update'])
     end
+
+    def last_update
+      return if related['last_update'].blank?
+      api.project_updates.find(related['last_update'])
+    end
   end
 end

--- a/lib/ansible_tower_client/logging.rb
+++ b/lib/ansible_tower_client/logging.rb
@@ -3,5 +3,11 @@ module AnsibleTowerClient
   module Logging
     extend Forwardable
     delegate :logger => :AnsibleTowerClient
+
+    def log_from_response(response)
+      JSON.parse(response.body).pretty_inspect
+    rescue JSON::ParserError
+      response.body
+    end
   end
 end

--- a/lib/ansible_tower_client/middleware/raise_tower_error.rb
+++ b/lib/ansible_tower_client/middleware/raise_tower_error.rb
@@ -7,9 +7,7 @@ module AnsibleTowerClient
       def on_complete(env)
         return unless CLIENT_ERROR_STATUSES.include?(env[:status])
         logger.debug { "#{self.class.name} Raw Response:\n#{env.pretty_inspect}" }
-        message   = JSON.parse(env.body).pretty_inspect rescue nil
-        message ||= env.body
-        logger.error("#{self.class.name} Response Body:\n#{message}")
+        logger.error("#{self.class.name} Response Body:\n#{log_from_response(env)}")
 
         case env[:status]
         when 402

--- a/spec/api_spec.rb
+++ b/spec/api_spec.rb
@@ -32,6 +32,14 @@ describe AnsibleTowerClient::Api do
           expect(subject.verify_credentials).to eq "admin"
         end
       end
+
+      describe "#method_missing" do
+        it "raises actual error, not NameError" do
+          error = 'some error'
+          expect(faraday_connection).to receive(:get).and_raise(error)
+          expect { subject.get }.to raise_error(error)
+        end
+      end
     end
   end
 

--- a/spec/api_spec.rb
+++ b/spec/api_spec.rb
@@ -34,6 +34,42 @@ describe AnsibleTowerClient::Api do
       end
 
       describe "#method_missing" do
+        let(:plain_response_body) { "some response" }
+        let(:json_response_body) { { "some_key" => "some_value" } }
+        let(:path_to_resource) { 'some/path' }
+
+        it "logs method call with formatted JSON response body" do
+          expect(subject).to receive(:build_path_to_resource).and_return(path_to_resource)
+
+          connection_response = instance_double("Faraday::Response", :body => json_response_body.to_json)
+          expect(faraday_connection).to receive(:get).and_return(connection_response)
+
+          expect(AnsibleTowerClient.logger).to receive(:debug) do |&block|
+            expect(block.call).to eq("AnsibleTowerClient::Api Sending <get> with <#{[path_to_resource].inspect}>")
+          end
+          expect(AnsibleTowerClient.logger).to receive(:debug) do |&block|
+            expect(block.call).to eq("AnsibleTowerClient::Api Response:\n#{json_response_body.pretty_inspect}")
+          end
+
+          subject.get
+        end
+
+        it "logs method call with plain text response body" do
+          expect(subject).to receive(:build_path_to_resource).and_return(path_to_resource)
+
+          connection_response = instance_double("Faraday::Response", :body => plain_response_body)
+          expect(faraday_connection).to receive(:get).and_return(connection_response)
+
+          expect(AnsibleTowerClient.logger).to receive(:debug) do |&block|
+            expect(block.call).to eq("AnsibleTowerClient::Api Sending <get> with <#{[path_to_resource].inspect}>")
+          end
+          expect(AnsibleTowerClient.logger).to receive(:debug) do |&block|
+            expect(block.call).to eq("AnsibleTowerClient::Api Response:\n#{plain_response_body}")
+          end
+
+          subject.get
+        end
+
         it "raises actual error, not NameError" do
           error = 'some error'
           expect(faraday_connection).to receive(:get).and_raise(error)

--- a/spec/factories/responses.rb
+++ b/spec/factories/responses.rb
@@ -26,7 +26,14 @@ FactoryGirl.define do
     type       { AnsibleTowerClient::FactoryHelper.underscore_string(klass.namespace.last) }
     name       { "#{type}-#{id}" }
     url        { "/api/v1/endpoint/" }
-    related    { {"survey_spec" => "example.com/api", 'inventory' => 'inventory link', 'stdout' => 'example.com/api'} }
+    related do
+      {
+        "survey_spec" => "example.com/api",
+        "inventory"   => "inventory link",
+        "stdout"      => "example.com/api",
+        "last_update" => "example.com/api"
+      }
+    end
     limit      { "" }
 
     trait(:description)  { sequence(:description) { |n| "description_#{n}" } }

--- a/spec/job_template_v2_spec.rb
+++ b/spec/job_template_v2_spec.rb
@@ -16,6 +16,7 @@ describe AnsibleTowerClient::JobTemplateV2 do
   describe '#launch' do
     let(:json) { {'extra_vars' => "{\"instance_ids\":[\"i-999c\"],\"state\":\"absent\",\"subnet_id\":\"subnet-887\"}"} }
     let(:post_result_body) { {:job => 1} }
+    let(:patch_result_body) { {} }
 
     let(:config) { {"version" => "2.1.1"} }
     it "runs an existing job template" do
@@ -27,7 +28,7 @@ describe AnsibleTowerClient::JobTemplateV2 do
     end
 
     it "handles limit when passed in" do
-      expect(connection).to receive(:patch).twice
+      expect(connection).to receive(:patch).twice.and_return(instance_double("Faraday::Response", :body => patch_result_body.to_json))
       described_class.new(api, raw_instance).send(:with_temporary_changes, 'test') { '' }
     end
 
@@ -59,7 +60,7 @@ describe AnsibleTowerClient::JobTemplateV2 do
       end.new
       expect(dummy).to receive(:body=).with("{ \"limit\": \"test_string\" }")
       expect(dummy).to receive(:body=).with("{ \"limit\": \"\" }")
-      expect(connection).to receive(:patch).twice.and_yield(dummy)
+      expect(connection).to receive(:patch).twice.and_yield(dummy).and_return(instance_double("Faraday::Response", :body => patch_result_body.to_json))
     end
   end
 end

--- a/spec/middleware/raise_tower_error_spec.rb
+++ b/spec/middleware/raise_tower_error_spec.rb
@@ -3,10 +3,15 @@ require 'ansible_tower_client/middleware/raise_tower_error'
 
 describe AnsibleTowerClient::Middleware::RaiseTowerError do
   context "Faraday::Error" do
-    let(:env_400) { MockEnv.new('missing these attributes', 400) }
-    let(:env_402) { MockEnv.new('missing these attributes', 402) }
-    let(:env_404) { MockEnv.new('missing these attributes', 404) }
-    let(:env_407) { MockEnv.new('missing these attributes', 407) }
+    let(:message) { 'missing these attributes' }
+
+    let(:env_400) { MockEnv.new(message, 400) }
+    let(:env_402) { MockEnv.new(message, 402) }
+    let(:env_404) { MockEnv.new(message, 404) }
+    let(:env_407) { MockEnv.new(message, 407) }
+
+    let(:obj) { {'error' => message} }
+    let(:env_json) { MockEnv.new(obj.to_json, 400) }
 
     let(:error) { AnsibleTowerClient::Middleware::RaiseTowerError.new }
 
@@ -21,9 +26,9 @@ describe AnsibleTowerClient::Middleware::RaiseTowerError do
         expect(block.call).to eq("#{described_class.name} Raw Response:\n#{env_400.pretty_inspect}")
       end
       expect(AnsibleTowerClient.logger).to receive(:error).with(
-        "AnsibleTowerClient::Middleware::RaiseTowerError Response Body:\nmissing these attributes"
+        "AnsibleTowerClient::Middleware::RaiseTowerError Response Body:\n#{env_400.body}"
       )
-      expect { error.on_complete(env_400) }.to raise_error(AnsibleTowerClient::ClientError, "missing these attributes")
+      expect { error.on_complete(env_400) }.to raise_error(AnsibleTowerClient::ClientError, message)
     end
 
     it "raises UnlicensedFeatureError with a status 402" do
@@ -31,7 +36,7 @@ describe AnsibleTowerClient::Middleware::RaiseTowerError do
         expect(block.call).to eq("#{described_class.name} Raw Response:\n#{env_402.pretty_inspect}")
       end
       expect(AnsibleTowerClient.logger).to receive(:error).with(
-        "AnsibleTowerClient::Middleware::RaiseTowerError Response Body:\nmissing these attributes"
+        "AnsibleTowerClient::Middleware::RaiseTowerError Response Body:\n#{env_402.body}"
       )
       expect { error.on_complete(env_402) }.to raise_error(AnsibleTowerClient::UnlicensedFeatureError)
     end
@@ -41,7 +46,7 @@ describe AnsibleTowerClient::Middleware::RaiseTowerError do
         expect(block.call).to eq("#{described_class.name} Raw Response:\n#{env_404.pretty_inspect}")
       end
       expect(AnsibleTowerClient.logger).to receive(:error).with(
-        "AnsibleTowerClient::Middleware::RaiseTowerError Response Body:\nmissing these attributes"
+        "AnsibleTowerClient::Middleware::RaiseTowerError Response Body:\n#{env_404.body}"
       )
       expect { error.on_complete(env_404) }.to raise_error(AnsibleTowerClient::ResourceNotFoundError)
     end
@@ -51,9 +56,16 @@ describe AnsibleTowerClient::Middleware::RaiseTowerError do
         expect(block.call).to eq("#{described_class.name} Raw Response:\n#{env_407.pretty_inspect}")
       end
       expect(AnsibleTowerClient.logger).to receive(:error).with(
-        "AnsibleTowerClient::Middleware::RaiseTowerError Response Body:\nmissing these attributes"
+        "AnsibleTowerClient::Middleware::RaiseTowerError Response Body:\n#{env_407.body}"
       )
       expect { error.on_complete(env_407) }.to raise_error(AnsibleTowerClient::ConnectionError)
+    end
+
+    it "logs error with formatted JSON response body" do
+      expect(AnsibleTowerClient.logger).to receive(:error).with(
+        "AnsibleTowerClient::Middleware::RaiseTowerError Response Body:\n#{obj.pretty_inspect}"
+      )
+      expect { error.on_complete(env_json) }.to raise_error(AnsibleTowerClient::ClientError)
     end
   end
 end

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -42,4 +42,28 @@ describe AnsibleTowerClient::Project do
       described_class.new(api, raw_instance).update
     end
   end
+
+  describe '#last_update' do
+    let(:project_update) { AnsibleTowerClient::ProjectUpdate.new(api, 'id' => 123) }
+
+    it "fetches last update" do
+      collection_double = instance_double("AnsibleTowerClient::Collection")
+      expect(api).to receive(:project_updates).and_return(collection_double)
+      expect(collection_double).to receive(:find).with(raw_instance['related']['last_update']).and_return(project_update)
+      actual_instance = described_class.new(api, raw_instance).last_update
+      expect(actual_instance).to equal(project_update)
+    end
+
+    it "does not fetch last update if missing" do
+      raw_instance['related'].delete('last_update')
+      result = described_class.new(api, raw_instance).last_update
+      expect(result).to be_nil
+    end
+
+    it "does not fetch last update if nil" do
+      raw_instance['related']['last_update'] = nil
+      result = described_class.new(api, raw_instance).last_update
+      expect(result).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
Add method to `Project` model that fetches stdout capture of its last update job. It uses `'related'` property of the Project. Returns `nil` if there is no update job for the Project.

Fetching and presenting this information is a workaround for cloning repositories from HTTPS servers with untrusted SSL certificates. Tower API does not offer an option to disable SSL check, so with the stdout user can at least see, why the cloning actually failed.

Alongside fix some subtle bugs in the `Api` class:

* Non-JSON responses were not logged correctly. This bug was hidden because with the default log level `debug` logs are skipped.
* `Faraday` was not available in the `Api` class, resulting it raising `LoadError` while catching `Faraday::*` exception.

https://bugzilla.redhat.com/show_bug.cgi?id=1513616

Required for [#72 in `manageiq-providers-ansible_tower`](https://github.com/ManageIQ/manageiq-providers-ansible_tower/pull/72).