### PR TITLE
Replace all characters that cannot be used as method or class name

### DIFF
--- a/lib/ansible_tower_client/hash_model.rb
+++ b/lib/ansible_tower_client/hash_model.rb
@@ -46,7 +46,8 @@ module AnsibleTowerClient
       end
 
       def convert_value(key, value, parent)
-        method = key_to_attribute(key)
+        method = key_to_attribute(key).gsub(/\W/, '_') # replace all unqualified characters for method and class names
+
         new_val =
           if attr_excluded?(method)
             value

--- a/spec/base_model_spec.rb
+++ b/spec/base_model_spec.rb
@@ -5,7 +5,8 @@ describe AnsibleTowerClient::BaseModel do
       "name"            => "jeff",
       "address"         => { "street" => "22 charlotte rd"},
       "serialized_json" => { "key" => "value"}.to_json,
-      "serialized_yaml" => { "key" => "value"}.to_yaml
+      "serialized_yaml" => { "key" => "value"}.to_yaml,
+      ":Special$ Key3"  => { "key" => "value"}
     }
   end
 
@@ -17,6 +18,7 @@ describe AnsibleTowerClient::BaseModel do
         expect(instance.name).to           eq("jeff")
         expect(instance.address).to        be_kind_of(described_class)
         expect(instance.address.street).to eq("22 charlotte rd")
+        expect(instance._special__key3).to be_kind_of(AnsibleTowerClient::BaseModel::SpecialKey3)
       end
     end
 


### PR DESCRIPTION
Any key in the original hash is used in the base model for two purpose:
1. underscore version is used as a method
2. camelized version is used as a class
Either case only accepts alphabetic letters, numbers, and _. All other characters are now replaced.

fixes https://bugzilla.redhat.com/show_bug.cgi?id=1583844