### PR TITLE
Gem::Version.new(nil) raises ArgumentError: Malformed version number string

### DIFF
--- a/spec/collection_spec.rb
+++ b/spec/collection_spec.rb
@@ -16,7 +16,7 @@ describe AnsibleTowerClient::Collection do
   ].freeze
 
   let(:connection)  { double("connection") }
-  let(:mock_api)    { AnsibleTowerClient::Api.new(connection) }
+  let(:mock_api)    { AnsibleTowerClient::Api.new(connection).tap { |a| a.instance_variable_set(:@version, "1.1") } }
   let(:instance)    { described_class.new(mock_api) }
   let(:test_url)    { "/api/v1/things/1/related_things/" }
   let(:get_options) { {"key" => "value"} }


### PR DESCRIPTION
In tests we weren't setting the version number for our mock api and this error was noticed when upgrading from Gem v2.7.6 to v2.7.7.

@bzwei @syncrou Please review, fixes test failures in https://github.com/ansible/ansible_tower_client_ruby/pull/105#issuecomment-393524937 since Travis is running with Gem v2.7.7