### PR TITLE
Support both API v1 and v2 at the same time

### DIFF
--- a/lib/ansible_tower_client.rb
+++ b/lib/ansible_tower_client.rb
@@ -33,6 +33,7 @@ require "ansible_tower_client/base_models/workflow_job_template"
 require "ansible_tower_client/base_models/workflow_job_template_node"
 
 require "ansible_tower_client/v2/job_template_v2"
+require "ansible_tower_client/v2/credential_v2"
 
 require "more_core_extensions/all"
 require "active_support/inflector"

--- a/lib/ansible_tower_client/connection.rb
+++ b/lib/ansible_tower_client/connection.rb
@@ -1,29 +1,67 @@
 module AnsibleTowerClient
   class Connection
-    attr_reader :connection
+    attr_reader :options
 
-    def initialize(options = nil)
+    # Options:
+    # - base_url: you have two options here:
+    #   a) pass in only scheme and hostname e.g. 'https://localhost:54321' to allow client to connect to both api v1
+    #      and v2 versions like this: `client.api(:version => 1)` and `client.api(:version => 2)`. This requires ansible
+    #      tower API being accessible directly at `https://localhost:54321/api/v1` and `https://localhost:54321/api/v2`.
+    #   b) pass in a complete api address e.g. 'https://localhost:54321/tower'. Client will then connect to the path
+    #      directly and it's your responsibility to know what version of API is there.
+    # - username
+    # - password
+    # - verify_ssl
+    def initialize(options = {})
       raise "Credentials are required" unless options[:username] && options[:password]
       raise ":base_url is required" unless options[:base_url]
-      verify_ssl = options[:verify_ssl] || OpenSSL::SSL::VERIFY_PEER
-      verify_ssl = verify_ssl == OpenSSL::SSL::VERIFY_NONE ? false : true
 
       require 'faraday'
       require 'faraday_middleware'
       require 'ansible_tower_client/middleware/raise_tower_error'
       Faraday::Response.register_middleware :raise_tower_error => -> { Middleware::RaiseTowerError }
-      @connection = Faraday.new(options[:base_url], :ssl => {:verify => verify_ssl}) do |f|
+
+      @options = {
+        :url        => options[:base_url],
+        :verify_ssl => (options[:verify_ssl] || OpenSSL::SSL::VERIFY_PEER) != OpenSSL::SSL::VERIFY_NONE,
+        :username   => options[:username],
+        :password   => options[:password]
+      }
+
+      reset
+    end
+
+    def connection(url:, username:, password:, verify_ssl: false)
+      Faraday.new(url, :ssl => {:verify => verify_ssl}) do |f|
         f.use(FaradayMiddleware::EncodeJson)
         f.use(FaradayMiddleware::FollowRedirects, :limit => 3, :standards_compliant => true)
         f.request(:url_encoded)
         f.response(:raise_tower_error)
         f.adapter(Faraday.default_adapter)
-        f.basic_auth(options[:username], options[:password])
+        f.basic_auth(username, password)
       end
     end
 
-    def api
-      @api ||= Api.new(connection)
+    def api(version: 2)
+      @api[version] ||= begin
+        # Build uri path.
+        options = @options.clone.tap do |opts|
+          opts[:url] = URI(opts[:url]).tap { |url| url.path = url_path_for_version(url.path, version) }
+        end
+
+        Api.new(connection(**options), version)
+      end
+    end
+
+    def reset
+      @api = {}
+    end
+
+    private
+
+    def url_path_for_version(orig_path, api_version)
+      return orig_path unless orig_path.sub(/\/$/, "").empty?
+      "/api/v#{api_version}"
     end
   end
 end

--- a/lib/ansible_tower_client/v2/credential_v2.rb
+++ b/lib/ansible_tower_client/v2/credential_v2.rb
@@ -1,0 +1,13 @@
+module AnsibleTowerClient
+  class CredentialV2 < Credential
+    class Inputs < BaseModel
+      def size
+        @raw_hash.keys.size
+      end
+    end
+
+    def self.endpoint
+      'credentials'
+    end
+  end
+end

--- a/spec/ad_hoc_command_spec.rb
+++ b/spec/ad_hoc_command_spec.rb
@@ -1,5 +1,5 @@
 describe AnsibleTowerClient::AdHocCommand do
-  let(:api)          { AnsibleTowerClient::Api.new(AnsibleTowerClient::MockApi.new) }
+  let(:api)          { AnsibleTowerClient::Api.new(AnsibleTowerClient::MockApi.new, 1) }
   let(:raw_instance) { build(:response_instance, :klass => described_class) }
 
   include_examples "Crud Methods"

--- a/spec/api_spec.rb
+++ b/spec/api_spec.rb
@@ -1,7 +1,8 @@
 describe AnsibleTowerClient::Api do
-  let(:faraday_connection) { AnsibleTowerClient::MockApi.new }
+  let(:faraday_connection) { AnsibleTowerClient::MockApi.new(:api_version => api_version) }
+  let(:api_version)        { 1 }
 
-  subject { described_class.new(faraday_connection) }
+  subject { described_class.new(faraday_connection, api_version) }
 
   it "#instance returns an existing instance" do
     expect(subject.instance).to be(faraday_connection)
@@ -76,6 +77,22 @@ describe AnsibleTowerClient::Api do
           expect { subject.get }.to raise_error(error)
         end
       end
+
+      describe "#api_version" do
+        describe "1" do
+          let(:api_version) { 1 }
+          it "returns api version that of instance" do
+            expect(subject.api_version).to eq(1)
+          end
+        end
+
+        describe "2" do
+          let(:api_version) { 2 }
+          it "returns api version that of instance" do
+            expect(subject.api_version).to eq(2)
+          end
+        end
+      end
     end
   end
 
@@ -126,7 +143,7 @@ describe AnsibleTowerClient::Api do
         it "connection path #{path}" do
           url = "https://server.example.com:8080#{path}"
           connection = AnsibleTowerClient::Connection.new(:username => "user", :password => "pass", :base_url => url)
-          api = connection.api
+          api = connection.api(:version => api_version)
 
           matrix.each do |default_path, corrected_path|
             expect(api.send(:build_path_to_resource, default_path)).to eq(corrected_path)

--- a/spec/collection_spec.rb
+++ b/spec/collection_spec.rb
@@ -19,7 +19,7 @@ describe AnsibleTowerClient::Collection do
   ].freeze
 
   let(:connection)  { double("connection") }
-  let(:mock_api)    { AnsibleTowerClient::Api.new(connection).tap { |a| a.instance_variable_set(:@version, "1.1") } }
+  let(:mock_api)    { AnsibleTowerClient::Api.new(connection, 1).tap { |a| a.instance_variable_set(:@version, "1.1") } }
   let(:instance)    { described_class.new(mock_api) }
   let(:test_url)    { "/api/v1/things/1/related_things/" }
   let(:get_options) { {"key" => "value"} }

--- a/spec/connection_spec.rb
+++ b/spec/connection_spec.rb
@@ -1,7 +1,19 @@
 describe AnsibleTowerClient::Connection do
   let(:base_options) { {:base_url => "https://example1.com", :username => "admin", :password => "smartvm", :verify_ssl => OpenSSL::SSL::VERIFY_NONE} }
+
+  subject { described_class.new(base_options) }
+
   it "#initialize returns a connection instance" do
     expect(described_class.new(base_options)).to be_a AnsibleTowerClient::Connection
+  end
+
+  it "#initialize sets options" do
+    expect(subject.options).to eq(
+      :url        => "https://example1.com",
+      :verify_ssl => false,
+      :username   => "admin",
+      :password   => "smartvm"
+    )
   end
 
   it ".new doesn't cache credentials across all instances" do
@@ -9,5 +21,50 @@ describe AnsibleTowerClient::Connection do
     conn_2 = described_class.new(base_options.merge(:base_url => "https://example2.com", :username => "user", :password => "password"))
 
     expect(conn_1.api.instance).not_to eq(conn_2.api.instance)
+  end
+
+  context ".api" do
+    it "defaults to api v2" do
+      expect(subject.api.api_version).to eq(2)
+    end
+
+    it "supports api v1" do
+      expect(subject.api(:version => 1).api_version).to eq(1)
+    end
+
+    it "dynamic switching between v1 and v2 won't interfere" do
+      expect(subject.api(:version => 1).api_version).to eq(1)
+      expect(subject.api(:version => 2).api_version).to eq(2)
+      expect(subject.api(:version => 1).api_version).to eq(1)
+      expect(subject.api(:version => 2).api_version).to eq(2)
+    end
+  end
+
+  context ".url_path_for_version" do
+    [
+      {
+        :case            => "basic base url",
+        :base_url        => "",
+        :expected_url_v1 => "/api/v1",
+        :expected_url_v2 => "/api/v2"
+      },
+      {
+        :case            => "hash-ended base url",
+        :base_url        => "/",
+        :expected_url_v1 => "/api/v1",
+        :expected_url_v2 => "/api/v2"
+      },
+      {
+        :case            => "custom base url",
+        :base_url        => "/custom/api/path",
+        :expected_url_v1 => "/custom/api/path",
+        :expected_url_v2 => "/custom/api/path"
+      }
+    ].each do |args|
+      it args[:case].to_s do
+        expect(subject.send(:url_path_for_version, args[:base_url], 1)).to eq(args[:expected_url_v1])
+        expect(subject.send(:url_path_for_version, args[:base_url], 2)).to eq(args[:expected_url_v2])
+      end
+    end
   end
 end

--- a/spec/credential_spec.rb
+++ b/spec/credential_spec.rb
@@ -1,5 +1,5 @@
 describe AnsibleTowerClient::Credential do
-  let(:api)          { AnsibleTowerClient::Api.new(AnsibleTowerClient::MockApi.new) }
+  let(:api)          { AnsibleTowerClient::Api.new(AnsibleTowerClient::MockApi.new(:api_version => 1), 1) }
   let(:raw_instance) { build(:response_instance, :credential, :klass => described_class) }
 
   include_examples "Crud Methods"

--- a/spec/group_spec.rb
+++ b/spec/group_spec.rb
@@ -1,6 +1,6 @@
 describe AnsibleTowerClient::Group do
   let(:url)          { "example.com/api/v1/groups" }
-  let(:api)          { AnsibleTowerClient::Api.new(AnsibleTowerClient::MockApi.new) }
+  let(:api)          { AnsibleTowerClient::Api.new(AnsibleTowerClient::MockApi.new, 1) }
   let(:raw_instance) { build(:response_instance, :group, :klass => described_class) }
 
   include_examples "Api Methods"

--- a/spec/host_spec.rb
+++ b/spec/host_spec.rb
@@ -1,6 +1,6 @@
 describe AnsibleTowerClient::Host do
   let(:url)          { "example.com/api/v1/hosts" }
-  let(:api)          { AnsibleTowerClient::Api.new(AnsibleTowerClient::MockApi.new) }
+  let(:api)          { AnsibleTowerClient::Api.new(AnsibleTowerClient::MockApi.new, 1) }
   let(:raw_instance) { build(:response_instance, :host, :klass => described_class) }
 
   include_examples "Api Methods"

--- a/spec/inventory_source_spec.rb
+++ b/spec/inventory_source_spec.rb
@@ -1,6 +1,6 @@
 describe AnsibleTowerClient::InventorySource do
   let(:url)          { "example.com/api/v1/inventory_sources" }
-  let(:api)          { AnsibleTowerClient::Api.new(AnsibleTowerClient::MockApi.new) }
+  let(:api)          { AnsibleTowerClient::Api.new(AnsibleTowerClient::MockApi.new, 1) }
   let(:raw_instance) { build(:response_instance, :klass => described_class) }
 
   include_examples "Api Methods"

--- a/spec/inventory_spec.rb
+++ b/spec/inventory_spec.rb
@@ -1,6 +1,6 @@
 describe AnsibleTowerClient::Inventory do
   let(:url)              { "example.com/api/v1/inventories" }
-  let(:api)              { AnsibleTowerClient::Api.new(AnsibleTowerClient::MockApi.new) }
+  let(:api)              { AnsibleTowerClient::Api.new(AnsibleTowerClient::MockApi.new, 1) }
   let(:inventory_source) { build(:response_url_collection, :klass => AnsibleTowerClient::InventorySource) }
   let(:raw_instance)     { build(:response_instance, :klass => described_class) }
   let(:instance)         { api.inventories.all.first }

--- a/spec/job_event_spec.rb
+++ b/spec/job_event_spec.rb
@@ -1,6 +1,6 @@
 describe AnsibleTowerClient::JobEvent do
   let(:url) { "example.com/api/v1/job_events" }
-  let(:api) { AnsibleTowerClient::Api.new(AnsibleTowerClient::MockApi.new) }
+  let(:api) { AnsibleTowerClient::Api.new(AnsibleTowerClient::MockApi.new, 1) }
 
   include_examples "Api Methods"
 end

--- a/spec/job_spec.rb
+++ b/spec/job_spec.rb
@@ -1,6 +1,6 @@
 describe AnsibleTowerClient::Job do
   let(:url)                        { "example.com/api/v1/jobs" }
-  let(:api)                        { AnsibleTowerClient::Api.new(AnsibleTowerClient::MockApi.new) }
+  let(:api)                        { AnsibleTowerClient::Api.new(AnsibleTowerClient::MockApi.new, 1) }
   let(:raw_instance)               { build(:response_instance, :job, :klass => described_class) }
   let(:raw_instance_no_extra_vars) { build(:response_instance, :job_template, :klass => described_class, :extra_vars => '') }
   let(:raw_instance_no_output)     { build(:response_instance, :job_template, :klass => described_class, :related => {}) }

--- a/spec/job_template_spec.rb
+++ b/spec/job_template_spec.rb
@@ -1,6 +1,6 @@
 describe AnsibleTowerClient::JobTemplate do
   let(:url)                        { "example.com/api/v1/job_templates" }
-  let(:api)                        { AnsibleTowerClient::Api.new(AnsibleTowerClient::MockApi.new("1.1")) }
+  let(:api)                        { AnsibleTowerClient::Api.new(AnsibleTowerClient::MockApi.new("1.1"), 1) }
   let(:raw_instance)               { build(:response_instance, :job_template, :klass => described_class) }
   let(:raw_instance_no_extra_vars) { build(:response_instance, :job_template, :klass => described_class, :extra_vars => '') }
   let(:raw_instance_no_survey)     { build(:response_instance, :job_template, :klass => described_class, :related => {}) }

--- a/spec/job_template_v2_spec.rb
+++ b/spec/job_template_v2_spec.rb
@@ -1,6 +1,6 @@
 describe AnsibleTowerClient::JobTemplateV2 do
   let(:url)                        { "example.com/api/v1/job_templates" }
-  let(:api)                        { AnsibleTowerClient::Api.new(connection) }
+  let(:api)                        { AnsibleTowerClient::Api.new(connection, 1) }
   let(:connection)                 { AnsibleTowerClient::MockApi.new("2.1") }
   let(:raw_instance)               { build(:response_instance, :job_template, :klass => described_class.base_class) }
   let(:raw_instance_no_extra_vars) { build(:response_instance, :job_template, :klass => described_class.base_class, :extra_vars => '') }

--- a/spec/organization_spec.rb
+++ b/spec/organization_spec.rb
@@ -1,5 +1,5 @@
 describe AnsibleTowerClient::Organization do
-  let(:api)          { AnsibleTowerClient::Api.new(AnsibleTowerClient::MockApi.new) }
+  let(:api)          { AnsibleTowerClient::Api.new(AnsibleTowerClient::MockApi.new, 1) }
   let(:raw_instance) { build(:response_instance, :organization, :klass => described_class, :description => "The Organization", :name => "MyOrg") }
 
   include_examples "Crud Methods"

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -1,6 +1,6 @@
 describe AnsibleTowerClient::Project do
   let(:url)          { "example.com/api/v1/projects" }
-  let(:api)          { AnsibleTowerClient::Api.new(AnsibleTowerClient::MockApi.new) }
+  let(:api)          { AnsibleTowerClient::Api.new(AnsibleTowerClient::MockApi.new, 1) }
   let(:raw_instance) { build(:response_instance, :project, :klass => described_class) }
 
   include_examples "Api Methods"

--- a/spec/support/mock_api.rb
+++ b/spec/support/mock_api.rb
@@ -1,14 +1,15 @@
 module AnsibleTowerClient
   class MockApi
     class Response
-      attr_reader :body
+      attr_reader :body, :api_version
       def initialize(body)
         @body = body
       end
     end
 
-    def initialize(version = nil)
-      @version = version
+    def initialize(version = nil, api_version: 2)
+      @awx_version = version
+      @api_version = api_version
     end
 
     def get(path, get_options = nil)
@@ -17,9 +18,13 @@ module AnsibleTowerClient
       when "ad_hoc_commands"
         wrap_response(AdHocCommand.response)
       when "config"
-        wrap_response(Config.response(@version))
+        wrap_response(Config.response(@awx_version))
       when "credentials"
-        wrap_response(Credential.response)
+        if api_version?(2)
+          wrap_response(CredentialV2.response)
+        else
+          wrap_response(Credential.response)
+        end
       when "groups"
         wrap_response(Group.response)
       when "hosts"
@@ -47,6 +52,10 @@ module AnsibleTowerClient
 
     def wrap_response(data)
       AnsibleTowerClient::MockApi::Response.new(data)
+    end
+
+    def api_version?(desired)
+      @api_version == desired
     end
   end
 end

--- a/spec/support/mock_api/v2/credential.rb
+++ b/spec/support/mock_api/v2/credential.rb
@@ -1,0 +1,172 @@
+module AnsibleTowerClient
+  class MockApi
+    module CredentialV2
+      def self.collection
+        [
+          {
+            :id              => 2,
+            :type            => "credential",
+            :url             => "/api/v2/credentials/2/",
+            :related         => {
+              :created_by      => "/api/v2/users/1/",
+              :modified_by     => "/api/v2/users/1/",
+              :organization    => "/api/v2/organizations/2/",
+              :owner_users     => "/api/v2/credentials/2/owner_users/",
+              :object_roles    => "/api/v2/credentials/2/object_roles/",
+              :owner_teams     => "/api/v2/credentials/2/owner_teams/",
+              :copy            => "/api/v2/credentials/2/copy/",
+              :activity_stream => "/api/v2/credentials/2/activity_stream/",
+              :access_list     => "/api/v2/credentials/2/access_list/",
+              :credential_type => "/api/v2/credential_types/1/"
+            },
+            :summary_fields  => {
+              :host              => {},
+              :project           => {},
+              :organization      => {
+                :id          => 2,
+                :name        => "ManageIQ",
+                :description => "ManageIQ Default Organization"
+              },
+              :created_by        => {
+                :id         => 1,
+                :username   => "admin",
+                :first_name => "",
+                :last_name  => ""
+              },
+              :modified_by       => {
+                :id         => 1,
+                :username   => "admin",
+                :first_name => "",
+                :last_name  => ""
+              },
+              :object_roles      => {
+                :admin_role => {
+                  :id          => 35,
+                  :description => "Can manage all aspects of the credential",
+                  :name        => "Admin"
+                },
+                :use_role   => {
+                  :id          => 37,
+                  :description => "Can use the credential in a job template",
+                  :name        => "Use"
+                },
+                :read_role  => {
+                  :id          => 36,
+                  :description => "May view settings for the credential",
+                  :name        => "Read"
+                }
+              },
+              :user_capabilities => {
+                :edit   => true,
+                :copy   => true,
+                :delete => true
+              },
+              :owners            => [
+                {
+                  :url         => "/api/v2/organizations/2/",
+                  :description => "ManageIQ Default Organization",
+                  :type        => "organization",
+                  :id          => 2,
+                  :name        => "ManageIQ"
+                }
+              ]
+            },
+            :created         => "2018-06-11T07:47:45.503385Z",
+            :modified        => "2018-06-11T07:47:45.567457Z",
+            :name            => "ManageIQ Default Credential",
+            :description     => "",
+            :organization    => 2,
+            :credential_type => 1,
+            :inputs          => {}
+          },
+          {
+            :id              => 3,
+            :type            => "credential",
+            :url             => "/api/v2/credentials/3/",
+            :related         => {
+              :created_by      => "/api/v2/users/1/",
+              :modified_by     => "/api/v2/users/1/",
+              :owner_users     => "/api/v2/credentials/3/owner_users/",
+              :object_roles    => "/api/v2/credentials/3/object_roles/",
+              :owner_teams     => "/api/v2/credentials/3/owner_teams/",
+              :copy            => "/api/v2/credentials/3/copy/",
+              :activity_stream => "/api/v2/credentials/3/activity_stream/",
+              :access_list     => "/api/v2/credentials/3/access_list/",
+              :credential_type => "/api/v2/credential_types/16/",
+              :user            => "/api/v2/users/1/"
+            },
+            :summary_fields  => {
+              :host              => {},
+              :project           => {},
+              :created_by        => {
+                :id         => 1,
+                :username   => "admin",
+                :first_name => "",
+                :last_name  => ""
+              },
+              :modified_by       => {
+                :id         => 1,
+                :username   => "admin",
+                :first_name => "",
+                :last_name  => ""
+              },
+              :object_roles      => {
+                :admin_role => {
+                  :id          => 43,
+                  :description => "Can manage all aspects of the credential",
+                  :name        => "Admin"
+                },
+                :use_role   => {
+                  :id          => 45,
+                  :description => "Can use the credential in a job template",
+                  :name        => "Use"
+                },
+                :read_role  => {
+                  :id          => 44,
+                  :description => "May view settings for the credential",
+                  :name        => "Read"
+                }
+              },
+              :user_capabilities => {
+                :edit   => true,
+                :copy   => true,
+                :delete => true
+              },
+              :owners            => [
+                {
+                  :url         => "/api/v2/users/1/",
+                  :description => " ",
+                  :type        => "user",
+                  :id          => 1,
+                  :name        => "admin"
+                }
+              ]
+            },
+            :created         => "2018-06-11T10:56:56.150390Z",
+            :modified        => "2018-06-11T10:56:56.247713Z",
+            :name            => "NuageGUI",
+            :description     => "",
+            :organization    => nil,
+            :credential_type => 16,
+            :inputs          => {
+              :nuage_username   => "myusername",
+              :nuage_password   => "$encrypted$",
+              :nuage_version    => "v5_0",
+              :nuage_enterprise => "myenterprise",
+              :nuage_url        => "myurl.com"
+            }
+          }
+        ]
+      end
+
+      def self.response
+        {
+          "count"    => collection.length,
+          "next"     => nil,
+          "previous" => nil,
+          "results"  => collection
+        }.to_json
+      end
+    end
+  end
+end

--- a/spec/system_job_template_spec.rb
+++ b/spec/system_job_template_spec.rb
@@ -1,5 +1,5 @@
 describe AnsibleTowerClient::SystemJobTemplate do
-  let(:api)          { AnsibleTowerClient::Api.new(AnsibleTowerClient::MockApi.new) }
+  let(:api)          { AnsibleTowerClient::Api.new(AnsibleTowerClient::MockApi.new, 1) }
   let(:raw_instance) { build(:response_instance, :system_job_template, :klass => described_class) }
 
   describe "#launch" do

--- a/spec/v2/credential_spec.rb
+++ b/spec/v2/credential_spec.rb
@@ -1,0 +1,31 @@
+describe AnsibleTowerClient::CredentialV2 do
+  let(:api)                        { AnsibleTowerClient::Api.new(connection, 2) }
+  let(:connection)                 { AnsibleTowerClient::MockApi.new }
+  let(:raw_instance)               { build(:response_instance, :credential, :klass => described_class) }
+
+  include_examples "Crud Methods"
+
+  it "#initialize instantiates an #{described_class} from a hash" do
+    obj = api.credentials.all.detect { |cred| cred.name == 'NuageGUI' }
+
+    expect(obj).to                    be_a described_class
+    expect(obj.id).to                 be_a Integer
+    expect(obj.url).to                be_a String
+    expect(obj.name).to               be_a String
+    expect(obj.credential_type_id).to be_a Integer
+    expect(obj.inputs).to             be_a AnsibleTowerClient::CredentialV2::Inputs
+    expect(obj.inputs.size).to        eq 5
+  end
+
+  context 'override_raw_attributes' do
+    let(:obj) { described_class.new(instance_double("Faraday::Connection"), raw_instance) }
+    let(:instance_api) { obj.instance_variable_get(:@api) }
+
+    it 'translates :organization to :organization_id for update_attributes' do
+      raw_instance[:organization_id] = 10
+      expect(instance_api).to receive(:patch).and_return(instance_double("Faraday::Result", :body => raw_instance.to_json))
+      expect(obj.update_attributes(:organization => '5')).to eq true
+      expect(obj.organization_id).to eq '5'
+    end
+  end
+end

--- a/spec/workflow_job_template_node_spec.rb
+++ b/spec/workflow_job_template_node_spec.rb
@@ -1,6 +1,6 @@
 describe AnsibleTowerClient::WorkflowJobTemplateNode do
   let(:url)                        { "example.com/api/v1/workflow_job_template_nodes" }
-  let(:api)                        { AnsibleTowerClient::Api.new(AnsibleTowerClient::MockApi.new("1.1")) }
+  let(:api)                        { AnsibleTowerClient::Api.new(AnsibleTowerClient::MockApi.new("1.1"), 1) }
   let(:raw_instance)               { build(:response_instance, :workflow_job_template_node, :klass => described_class) }
 
   include_examples "Api Methods"

--- a/spec/workflow_job_template_spec.rb
+++ b/spec/workflow_job_template_spec.rb
@@ -1,6 +1,6 @@
 describe AnsibleTowerClient::WorkflowJobTemplate do
   let(:url)                        { "example.com/api/v1/workflow_job_templates" }
-  let(:api)                        { AnsibleTowerClient::Api.new(AnsibleTowerClient::MockApi.new("1.1")) }
+  let(:api)                        { AnsibleTowerClient::Api.new(AnsibleTowerClient::MockApi.new("1.1"), 1) }
   let(:raw_instance)               { build(:response_instance, :workflow_job_template, :klass => described_class) }
   let(:raw_instance_no_extra_vars) { build(:response_instance, :workflow_job_template, :klass => described_class, :extra_vars => '') }
   let(:raw_instance_no_survey)     { build(:response_instance, :workflow_job_template, :klass => described_class, :related => {}) }


### PR DESCRIPTION
With this commit we allow user to quickly switch between v1 and v2 per API call:

```ruby
client = AnsibleTowerClient::Connection.new(
  :base_url   => 'http://localhost:54321',
  :username   => 'admin',
  :password   => 'password'
)

# Credentials from API v1
client.api(:version => 1).credentials.all.each do |c|
  pp c
end

# Credentials from API v2
client.api(:version => 2).credentials.all.each do |c|
  pp c
end
```

This way migrating ManageIQ to use v2 will be easier because we can migrate API call by API call.

Related issue: https://github.com/ManageIQ/manageiq-providers-ansible_tower/issues/96