### PR TITLE
API call for credential types

### DIFF
--- a/lib/ansible_tower_client.rb
+++ b/lib/ansible_tower_client.rb
@@ -34,6 +34,7 @@ require "ansible_tower_client/base_models/workflow_job_template_node"
 
 require "ansible_tower_client/v2/job_template_v2"
 require "ansible_tower_client/v2/credential_v2"
+require "ansible_tower_client/v2/credential_type_v2"
 
 require "more_core_extensions/all"
 require "active_support/inflector"

--- a/lib/ansible_tower_client/api.rb
+++ b/lib/ansible_tower_client/api.rb
@@ -36,6 +36,11 @@ module AnsibleTowerClient
       Collection.new(self, credential_class)
     end
 
+    def credential_types
+      raise AnsibleTowerClient::UnsupportedApiError, 'requires API v2 or higher' if api_version?(1)
+      Collection.new(self, credential_type_class)
+    end
+
     def groups
       Collection.new(self, group_class)
     end
@@ -150,6 +155,10 @@ module AnsibleTowerClient
           AnsibleTowerClient::Credential
         end
       end
+    end
+
+    def credential_type_class
+      @credential_type_class ||= AnsibleTowerClient::CredentialTypeV2
     end
 
     def group_class

--- a/lib/ansible_tower_client/exception.rb
+++ b/lib/ansible_tower_client/exception.rb
@@ -7,4 +7,5 @@ module AnsibleTowerClient
   class ResourceNotFoundError  < ClientError; end
   class SSLError               < ClientError; end
   class UnlicensedFeatureError < ClientError; end
+  class UnsupportedApiError    < ClientError; end
 end

--- a/lib/ansible_tower_client/v2/credential_type_v2.rb
+++ b/lib/ansible_tower_client/v2/credential_type_v2.rb
@@ -1,0 +1,9 @@
+module AnsibleTowerClient
+  class CredentialTypeV2 < BaseModel
+    class Inputs < BaseModel; end
+
+    def self.endpoint
+      'credential_types'
+    end
+  end
+end

--- a/spec/factories/responses.rb
+++ b/spec/factories/responses.rb
@@ -46,6 +46,7 @@ FactoryGirl.define do
     trait(:username)     { username { "random username" } }
 
     trait(:credential)                  { [description, kind, username] }
+    trait(:credential_type)             { [description, kind] }
     trait(:group)                       { [description, inventory_id] }
     trait(:host)                        { [description, instance_id, inventory_id] }
     trait(:job_template)                { [description, extra_vars] }

--- a/spec/support/mock_api.rb
+++ b/spec/support/mock_api.rb
@@ -25,6 +25,8 @@ module AnsibleTowerClient
         else
           wrap_response(Credential.response)
         end
+      when "credential_types"
+        wrap_response(CredentialTypeV2.response)
       when "groups"
         wrap_response(Group.response)
       when "hosts"

--- a/spec/support/mock_api/v2/credential_type.rb
+++ b/spec/support/mock_api/v2/credential_type.rb
@@ -1,0 +1,60 @@
+module AnsibleTowerClient
+  class MockApi
+    module CredentialTypeV2
+      def self.collection
+        [
+          {
+            :id               => 16,
+            :type             => "credential_type",
+            :url              => "/api/v2/credential_types/16/",
+            :related          => {
+              :created_by      => "/api/v2/users/1/",
+              :modified_by     => "/api/v2/users/1/",
+              :credentials     => "/api/v2/credential_types/16/credentials/",
+              :activity_stream => "/api/v2/credential_types/16/activity_stream/"
+            },
+            :summary_fields   => {
+              :created_by        => {:id => 1, :username => "admin", :first_name => "", :last_name => ""},
+              :modified_by       => {:id => 1, :username => "admin", :first_name => "", :last_name => ""},
+              :user_capabilities => {:edit => true, :delete => true}
+            },
+            :created          => "2018-06-18T20:02:15.415325Z",
+            :modified         => "2018-06-18T20:02:15.415353Z",
+            :name             => "Nuage",
+            :description      => "",
+            :kind             => "cloud",
+            :managed_by_tower => false,
+            :inputs           => {
+              :fields   => [
+                {:type => "string", :id => "nuage_username", :label => "Username"},
+                {:secret => true, :type => "string", :id => "nuage_password", :label => "Password"},
+                {:type => "string", :id => "nuage_enterprise", :label => "Enterprise"},
+                {:type => "string", :id => "nuage_url", :label => "URL"},
+                {:choices => %w(v4_0 v5_0), :type => "string", :id => "nuage_version", :label => "Version"}
+              ],
+              :required => %w(nuage_username nuage_password nuage_enterprise nuage_url nuage_version)
+            },
+            :injectors        => {
+              :extra_vars => {
+                :nuage_username   => "{{ nuage_username }}",
+                :nuage_password   => "{{ nuage_password }}",
+                :nuage_version    => "{{ nuage_version }}",
+                :nuage_enterprise => "{{ nuage_enterprise }}",
+                :nuage_url        => "{{ nuage_url }}"
+              }
+            }
+          }
+        ]
+      end
+
+      def self.response
+        {
+          "count"    => collection.length,
+          "next"     => nil,
+          "previous" => nil,
+          "results"  => collection
+        }.to_json
+      end
+    end
+  end
+end

--- a/spec/v2/credential_type_spec.rb
+++ b/spec/v2/credential_type_spec.rb
@@ -1,0 +1,27 @@
+describe AnsibleTowerClient::CredentialTypeV2 do
+  let(:api)                        { AnsibleTowerClient::Api.new(connection, 2) }
+  let(:connection)                 { AnsibleTowerClient::MockApi.new }
+  let(:raw_instance)               { build(:response_instance, :credential_type, :klass => described_class) }
+
+  include_examples "Crud Methods"
+
+  it "#initialize instantiates an #{described_class} from a hash" do
+    obj = api.credential_types.all.detect { |cred| cred.name == 'Nuage' }
+
+    expect(obj).to                    be_a described_class
+    expect(obj.id).to                 be_a Integer
+    expect(obj.url).to                be_a String
+    expect(obj.name).to               be_a String
+    expect(obj.kind).to               be_a String
+    expect(obj.managed_by_tower).to   eq false
+    expect(obj.inputs).to             be_a AnsibleTowerClient::CredentialTypeV2::Inputs
+    expect(obj.inputs.fields).to      be_a Array
+    expect(obj.inputs.required).to    be_a Array
+    expect(obj.injectors).to          be_a AnsibleTowerClient::CredentialTypeV2::Injectors
+  end
+
+  context 'override_raw_attributes' do
+    let(:obj) { described_class.new(instance_double("Faraday::Connection"), raw_instance) }
+    let(:instance_api) { obj.instance_variable_get(:@api) }
+  end
+end


### PR DESCRIPTION
With this commit we add a new API call which is only supported on API v2:

```
client.api.credential_types
```

It returns a list of all credential types as well as offer CRUD for them.