### PR TITLE
handling workflow_job_node not started yet

### DIFF
--- a/lib/ansible_tower_client/base_models/workflow_job_node.rb
+++ b/lib/ansible_tower_client/base_models/workflow_job_node.rb
@@ -5,7 +5,7 @@ module AnsibleTowerClient
     end
 
     def job
-      super.nil? ? nil : api.jobs.find(job_id)
+      !respond_to?(:job_id) || job_id.nil? ? nil : api.jobs.find(job_id)
     end
   end
 end

--- a/lib/ansible_tower_client/base_models/workflow_job_node.rb
+++ b/lib/ansible_tower_client/base_models/workflow_job_node.rb
@@ -5,7 +5,7 @@ module AnsibleTowerClient
     end
 
     def job
-      job_id.nil? ? nil : api.jobs.find(job_id)
+      super.nil? ? nil : api.jobs.find(job_id)
     end
   end
 end

--- a/lib/ansible_tower_client/base_models/workflow_job_node.rb
+++ b/lib/ansible_tower_client/base_models/workflow_job_node.rb
@@ -5,7 +5,7 @@ module AnsibleTowerClient
     end
 
     def job
-      !respond_to?(:job_id) || job_id.nil? ? nil : api.jobs.find(job_id)
+      api.jobs.find(job_id) if respond_to?(:job_id) && job_id
     end
   end
 end

--- a/spec/support/mock_api/workflow_job_node.rb
+++ b/spec/support/mock_api/workflow_job_node.rb
@@ -6,6 +6,46 @@ module AnsibleTowerClient
           {
             "id": 1,
             "type": "workflow_job_node",
+            "url": "/api/v1/workflow_job_nodes/2/",
+            "related": {
+              "unified_job_template": "/api/v1/job_templates/216/",
+              "success_nodes": "/api/v1/workflow_job_nodes/1/success_nodes/",
+              "failure_nodes": "/api/v1/workflow_job_nodes/1/failure_nodes/",
+              "always_nodes": "/api/v1/workflow_job_nodes/1/always_nodes/",
+              "workflow_job": "/api/v1/workflow_jobs/428/"
+            },
+            "summary_fields": {
+              "workflow_job": {
+                "id": 428,
+                "name": "james-wf2",
+                "description": ""
+              },
+              "unified_job_template": {
+                "id": 216,
+                "name": "Demo Job Template",
+                "description": "",
+                "unified_job_type": "job"
+              }
+            },
+            "created": "2018-05-17T13:13:48.022Z",
+            "modified": "2018-05-17T13:13:51.562Z",
+            "unified_job_template": 216,
+            "success_nodes": [],
+            "failure_nodes": [],
+            "always_nodes": [
+                2
+            ],
+            "inventory": nil,
+            "credential": nil,
+            "job_type": nil,
+            "job_tags": nil,
+            "skip_tags": nil,
+            "limit": nil,
+            "workflow_job": 428
+          },
+          {
+            "id": 2,
+            "type": "workflow_job_node",
             "url": "/api/v1/workflow_job_nodes/1/",
             "related": {
               "unified_job_template": "/api/v1/job_templates/216/",

--- a/spec/workflow_job_node_spec.rb
+++ b/spec/workflow_job_node_spec.rb
@@ -7,12 +7,23 @@ describe AnsibleTowerClient::WorkflowJobNode do
   include_examples "Crud Methods"
 
   it "#initialize instantiates an #{described_class} from a hash" do
-    obj = api.workflow_job_nodes.all.first
+    obj = api.workflow_job_nodes.all.to_a[1]
 
     expect(obj).to                    be_a described_class
     expect(obj.id).to                 be_a Integer
     expect(obj.job_id).to             be_a Integer
     expect(obj.workflow_job_id).to    be_a Integer
     expect(obj.related).to            be_a described_class::Related
+  end
+
+  it "#job returns a nil when the job_id is not set or nil" do
+    obj = api.workflow_job_nodes.all.first
+    expect(obj.job).to be_nil
+  end
+
+  it "#job returns a Job when the job_id is set" do
+    obj = api.workflow_job_nodes.all.to_a[1]
+    allow(api).to receive(:get).and_return(instance_double("Faraday::Result", :body => {}.to_json))
+    expect(obj.job).to be_a AnsibleTowerClient::Job
   end
 end


### PR DESCRIPTION
When a workflow is launched, some of the the `workflow_job_nodes` won't have their job started and accessing the `job` will fail. This will fix that and return `nil`
