### PR TITLE
Default API version to 1

### DIFF
--- a/lib/ansible_tower_client/connection.rb
+++ b/lib/ansible_tower_client/connection.rb
@@ -45,7 +45,7 @@ module AnsibleTowerClient
       end
     end
 
-    def api(version: 2)
+    def api(version: 1)
       @api[version] ||= begin
         # Build uri path.
         options = @options.clone.tap do |opts|

--- a/spec/connection_spec.rb
+++ b/spec/connection_spec.rb
@@ -26,8 +26,8 @@ describe AnsibleTowerClient::Connection do
   end
 
   context ".api" do
-    it "defaults to api v2" do
-      expect(subject.api.api_version).to eq(2)
+    it "defaults to api v1" do
+      expect(subject.api.api_version).to eq(1)
     end
 
     it "supports api v1" do


### PR DESCRIPTION
The major consumer of this gem is `manageiq-providers-ansible_tower` and which is based on v1 api. Before `manageiq-providers-ansible_tower` support v2 in, we shall keep this gem. And besides currently only the `credential_type` from v2 is supported in this gem.

