### PR TITLE
Require 'openssl' in connections

### DIFF
--- a/lib/ansible_tower_client/connection.rb
+++ b/lib/ansible_tower_client/connection.rb
@@ -1,3 +1,5 @@
+require 'openssl'
+
 module AnsibleTowerClient
   class Connection
     attr_reader :connection


### PR DESCRIPTION
Connection logic currently utilizes the OpenSSL module directly but
doesn't require it, throwing an error under certain circumstances.

This is easily reproduced with the following code:
```
require 'ansible_tower_client'

ansible = AnsibleTowerClient::Connection.new(username: "admin",
					     password: "tower-password",
                                             base_url: "https://tower-address.com",
                                             verify_ssl: true)

inventories = ansible.api.inventories
inventories.all.each { |inventory| puts inventory }
```

And creates the following error, as it searches for `OpenSSL` in the
context of the current module, which doesn't exist (but is a
part of faraday it seems).
```
Traceback (most recent call last):
	2: from ansible_reproducer.rb:3:in `<main>'
	1: from ansible_reproducer.rb:3:in `new'
/var/lib/gems/2.5.0/gems/ansible_tower_client-0.18.0/lib/ansible_tower_client/connection.rb:9:in `initialize': uninitialized constant AnsibleTowerClient::Connection::OpenSSL (NameError)
Did you mean?  OpenStruct
```

Adding `require 'openssl'` to the top of the file resolves this.