### PR TITLE
Tower 3.3 removed result_stdout field from project_update

### DIFF
--- a/lib/ansible_tower_client/base_models/project_update.rb
+++ b/lib/ansible_tower_client/base_models/project_update.rb
@@ -1,4 +1,8 @@
 module AnsibleTowerClient
   class ProjectUpdate < BaseModel
+    def stdout(format = 'txt')
+      api.get("#{related['stdout']}?format=#{format}").body
+    end
+    alias result_stdout stdout
   end
 end

--- a/spec/project_update_spec.rb
+++ b/spec/project_update_spec.rb
@@ -15,4 +15,20 @@ describe AnsibleTowerClient::ProjectUpdate do
     expect(obj.id).to   be_a Integer
     expect(obj.name).to be_a String
   end
+
+  context '#stdout' do
+    describe "exists" do
+      let(:stdout) { "Ansible Tower Project Update output" }
+
+      it "returns stdout default to plain text" do
+        expect(api).to receive(:get).with(/format=txt/).and_return(instance_double("Faraday::Result", :body => stdout))
+        expect(described_class.new(api, raw_instance).stdout).to eq(stdout)
+      end
+
+      it "returns formatted text per request" do
+        expect(api).to receive(:get).with(/format=html/).and_return(instance_double("Faraday::Result", :body => stdout))
+        expect(described_class.new(api, raw_instance).stdout('html')).to eq(stdout)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fixing https://github.com/ManageIQ/manageiq-automation_engine/issues/261

Related https://github.com/ManageIQ/manageiq-providers-ansible_tower/pull/140