### PR TITLE
little improvements

### DIFF
--- a/lib/ansible_tower_client/api.rb
+++ b/lib/ansible_tower_client/api.rb
@@ -12,7 +12,7 @@ module AnsibleTowerClient
     end
 
     def config
-      JSON.parse(get("config").body)
+      JSON.parse(get("config/").body)
     end
 
     def version

--- a/lib/ansible_tower_client/collection.rb
+++ b/lib/ansible_tower_client/collection.rb
@@ -9,7 +9,7 @@ module AnsibleTowerClient
     # @param get_options [Hash] a hash of http GET params to pass to the api request
     #   e.g. { :order_by => 'timestamp', :name__contains => 'foo' }
     def all(get_options = nil)
-      find_all_by_url(klass.endpoint, get_options)
+      find_all_by_url("#{klass.endpoint}/", get_options)
     end
 
     def find_all_by_url(url, get_options = nil)

--- a/lib/ansible_tower_client/middleware/raise_tower_error.rb
+++ b/lib/ansible_tower_client/middleware/raise_tower_error.rb
@@ -23,7 +23,12 @@ module AnsibleTowerClient
       end
 
       def response_values(env)
-        {:status => env.status, :headers => env.response_headers, :body => env.body}
+        {
+          :headers => env.response_headers,
+          :status  => env.status,
+          :body    => env.body,
+          :url     => env.url,
+        }
       end
     end
   end

--- a/spec/collection_spec.rb
+++ b/spec/collection_spec.rb
@@ -36,7 +36,7 @@ describe AnsibleTowerClient::Collection do
         allow(mock_api).to receive(:config).and_return({}) # For Job Template class
         collection = described_class.new(mock_api, klass)
         expect(described_class).to receive(:new).with(mock_api, klass).and_return(collection)
-        expect(collection).to receive(:find_all_by_url).with(klass.endpoint, any_args)
+        expect(collection).to receive(:find_all_by_url).with("#{klass.endpoint}/", any_args)
 
         mock_api.send(collection_class).all
       end

--- a/spec/middleware/raise_tower_error_spec.rb
+++ b/spec/middleware/raise_tower_error_spec.rb
@@ -70,4 +70,4 @@ describe AnsibleTowerClient::Middleware::RaiseTowerError do
   end
 end
 
-class MockEnv < Struct.new(:body, :status, :response_headers); end
+MockEnv = Struct.new(:body, :status, :response_headers, :url)

--- a/spec/support/mock_api.rb
+++ b/spec/support/mock_api.rb
@@ -1,11 +1,32 @@
 module AnsibleTowerClient
   class MockApi
     class Response
-      attr_reader :body
-      def initialize(body)
+      attr_reader :body, :url
+
+      def initialize(body, url = nil)
         @body = body
+        @url  = url
       end
     end
+
+    RESPONSES = {
+      'ad_hoc_commands'             => 'AdHocCommand',
+      'config'                      => 'Config',
+      'credentials'                 => 'Credential',
+      'groups'                      => 'Group',
+      'hosts'                       => 'Host',
+      'inventories'                 => 'Inventory',
+      'inventory_sources'           => 'InventorySource',
+      'jobs'                        => 'Job',
+      'job_templates'               => 'JobTemplate',
+      'organizations'               => 'Organization',
+      'projects'                    => 'Project',
+      'me'                          => 'Me',
+      'workflow_jobs'               => 'WorkflowJob',
+      'workflow_job_nodes'          => 'WorkflowJobNode',
+      'workflow_job_template_nodes' => 'WorkflowJobTemplateNode',
+      'workflow_job_templates'      => 'WorkflowJobTemplate',
+    }.freeze
 
     def initialize(version = nil)
       @version = version
@@ -13,44 +34,15 @@ module AnsibleTowerClient
 
     def get(path, get_options = nil)
       suffix = path.split("api/v1/").last
-      case suffix
-      when "ad_hoc_commands"
-        wrap_response(AdHocCommand.response)
-      when "config"
-        wrap_response(Config.response(@version))
-      when "credentials"
-        wrap_response(Credential.response)
-      when "groups"
-        wrap_response(Group.response)
-      when "hosts"
-        wrap_response(Host.response)
-      when "inventories"
-        wrap_response(Inventory.response)
-      when "inventory_sources"
-        wrap_response(InventorySource.response)
-      when "jobs"
-        wrap_response(Job.response)
-      when "job_templates"
-        wrap_response(JobTemplate.response)
-      when "organizations"
-        wrap_response(Organization.response)
-      when "projects"
-        wrap_response(Project.response)
-      when "me"
-        wrap_response(Me.response)
-      when "workflow_jobs"
-        wrap_response(WorkflowJob.response)
-      when "workflow_job_nodes"
-        wrap_response(WorkflowJobNode.response)
-      when "workflow_job_template_nodes"
-        wrap_response(WorkflowJobTemplateNode.response)
-      when "workflow_job_templates"
-        wrap_response(WorkflowJobTemplate.response)
-      end
-    end
+      suffix = suffix[0..-2] if suffix.end_with?('/')
+      response_module = RESPONSES.fetch(suffix)
 
-    def wrap_response(data)
-      AnsibleTowerClient::MockApi::Response.new(data)
+      args = []
+      args << @version if response_module == 'Config'
+
+      response_class = AnsibleTowerClient::MockApi.const_get(response_module)
+      response_data  = response_class.response(*args)
+      AnsibleTowerClient::MockApi::Response.new(response_data, path)
     end
   end
 end


### PR DESCRIPTION
**avoid redundant redirects**

Currently, base resource paths got requested without trailing slashes in addresses.
It leads so such lines in the logs:
```
INFO -- : get https://example.com/api/v2/config
INFO -- Status: 301
INFO -- : get https://example.com/api/v2/config/
INFO -- Status: 200
INFO -- : get https://example.com/api/v2/inventories
INFO -- Status: 301
INFO -- : get https://example.com/api/v2/inventories/
INFO -- Status: 200
```
This commit eliminates useless redirect hops.


**unhide url of not found resource**

Ease `404`-related errors debugging.