### PR TITLE
[ruby 2.5] Ensure no double trailing slash

### DIFF
--- a/lib/ansible_tower_client/collection.rb
+++ b/lib/ansible_tower_client/collection.rb
@@ -28,7 +28,7 @@ module AnsibleTowerClient
     end
 
     def find(id)
-      build_object(parse_response(api.get("#{klass.endpoint}/#{id}/")))
+      build_object(parse_response(api.get(find_uri(id))))
     end
 
     def create!(*args)
@@ -49,6 +49,10 @@ module AnsibleTowerClient
       return if next_page.nil?
       body = parse_response(api.get(next_page, get_options))
       parse_result_set(body)
+    end
+
+    def find_uri(id)
+      File.join(klass.endpoint, id.to_s, "/")
     end
 
     def parse_response(response)

--- a/spec/collection_spec.rb
+++ b/spec/collection_spec.rb
@@ -55,6 +55,14 @@ describe AnsibleTowerClient::Collection do
         expect(mock_api.send(collection_class).find(1)).to be_instance_of(klass)
       end
     end
+
+    it "#find_uri(private)" do
+      expect(mock_api.projects.send(:find_uri, 1)).to eq "projects/1/"
+    end
+
+    it "#find_uri(private) with related updates" do
+      expect(mock_api.projects.send(:find_uri, "project_updates/1/")).to eq "projects/project_updates/1/"
+    end
   end
 
   context "#find_all_by_url" do


### PR DESCRIPTION
Related project updates perform a find with an id with a trailing slash,
such as 'project_updates/233/'.  Previously, we'd append another
trailing slash and it would be up to the underlying faraday code to fix it.

On ruby 2.5.x, faraday would receive two trailing slashes and not fix
it.  On ruby 2.4.x, we'd send two trailing slashes to faraday
but it would perform the get with only a single trailing slash.

It's unclear what changed in ruby 2.4 vs. 2.5 to behave differently with the same
faraday and other gems, but it's better to ensure we don't try to send an invalid
URI to faraday.