### PR TITLE
Update bundler, rake, remove unnecessary load path mangling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 rvm:
-  - "2.3.1"
-  - "2.4.1"
+  - "2.4.5"
+  - "2.5.3"
 sudo: false
 cache: bundler
-before_install: gem install bundler -v 2.0.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ rvm:
   - "2.4.1"
 sudo: false
 cache: bundler
-before_install: gem install bundler -v 1.10.3
+before_install: gem install bundler -v 2.0.1

--- a/ansible_tower_client.gemspec
+++ b/ansible_tower_client.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "faraday_middleware"
   spec.add_runtime_dependency "more_core_extensions", "~> 3.0"
 
-  spec.add_development_dependency "factory_bot", "~> 4.11.1"
-  spec.add_development_dependency "rake", "~> 12.3.2"
+  spec.add_development_dependency "factory_bot", "~> 4.11"
+  spec.add_development_dependency "rake", "~> 12.3"
   spec.add_development_dependency "rspec"
 end

--- a/ansible_tower_client.gemspec
+++ b/ansible_tower_client.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "faraday_middleware"
   spec.add_runtime_dependency "more_core_extensions", "~> 3.0"
 
-  spec.add_development_dependency "bundler", "~> 2.0.1"
   spec.add_development_dependency "factory_bot", "~> 4.11.1"
   spec.add_development_dependency "rake", "~> 12.3.2"
   spec.add_development_dependency "rspec"

--- a/ansible_tower_client.gemspec
+++ b/ansible_tower_client.gemspec
@@ -1,7 +1,5 @@
 # coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'ansible_tower_client/version'
+require_relative 'lib/ansible_tower_client/version'
 
 Gem::Specification.new do |spec|
   spec.name          = "ansible_tower_client"
@@ -17,15 +15,14 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
-  spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "activesupport"
   spec.add_runtime_dependency "faraday"
   spec.add_runtime_dependency "faraday_middleware"
   spec.add_runtime_dependency "more_core_extensions", "~> 3.0"
 
-  spec.add_development_dependency "bundler", "~> 1.10"
-  spec.add_development_dependency "factory_girl"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "bundler", "~> 2.0.1"
+  spec.add_development_dependency "factory_bot", "~> 4.11.1"
+  spec.add_development_dependency "rake", "~> 12.3.2"
   spec.add_development_dependency "rspec"
 end

--- a/spec/factories/responses.rb
+++ b/spec/factories/responses.rb
@@ -1,20 +1,20 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :response_collection, :class => "Hash" do
-    count    2
+    count    { 2 }
     "next"   ""
-    previous ""
-    klass    ""
+    previous { "" }
+    klass    { "" }
     results  { count.times.collect { build(:response_instance, :klass => klass) } }
 
     initialize_with { AnsibleTowerClient::FactoryHelper.stringify_attribute_keys(attributes) }
   end
 
   factory :response_url_collection, :class => "Hash" do
-    count    1
+    count    { 1 }
     "next"   ""
-    previous ""
-    klass    ""
-    url      ""
+    previous { "" }
+    klass    { "" }
+    url      { "" }
     results  { count.times.collect { build(:response_instance, :klass => klass, :url => url) } }
 
     initialize_with { AnsibleTowerClient::FactoryHelper.stringify_attribute_keys(attributes) }
@@ -22,7 +22,7 @@ FactoryGirl.define do
 
   factory :response_instance, :class => "Hash" do
     sequence(:id)
-    klass      ""
+    klass      { "" }
     type       { AnsibleTowerClient::FactoryHelper.underscore_string(klass.namespace.last) }
     name       { "#{type}-#{id}" }
     url        { "/api/v1/endpoint/" }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,12 +1,12 @@
 gem_root = Gem::Specification.find_by_name("ansible_tower_client").gem_dir
 Dir[File.join(gem_root, "spec/support/**/*.rb")].each { |f| require f }
 
-require 'factory_girl'
-FactoryGirl.find_definitions
+require 'factory_bot'
+FactoryBot.find_definitions
 
 RSpec.configure do |config|
   config.order = :random
-  config.include FactoryGirl::Syntax::Methods
+  config.include FactoryBot::Syntax::Methods
 end
 
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)


### PR DESCRIPTION
This updates the gemspec by updating the bundler and rake versions, removes some unnecessary load path mangling, and gets rid of the `require_paths` specification since 'lib' is already the default.

Edit: also realized factory_girl needed to be updated to factory_bot.