### PR TITLE
Add logic to filter out workflow job node that is for sync

### DIFF
--- a/lib/ansible_tower_client/base_models/workflow_job_node.rb
+++ b/lib/ansible_tower_client/base_models/workflow_job_node.rb
@@ -5,7 +5,14 @@ module AnsibleTowerClient
     end
 
     def job
-      api.jobs.find(job_id) if respond_to?(:job_id) && job_id
+      api.jobs.find(job_id) if job?
+    end
+
+    # to filter out WorkflowJobNode that is inventory sync or project sync
+    def job?
+      return false if !respond_to?(:job_id) || job_id.nil?
+
+      related.job.match?(/jobs/)
     end
   end
 end

--- a/spec/workflow_job_node_spec.rb
+++ b/spec/workflow_job_node_spec.rb
@@ -34,10 +34,17 @@ describe AnsibleTowerClient::WorkflowJobNode do
     end
 
     it "returns a Job when the job_id is set" do
-      obj = described_class.new(api, response_with_job(raw_instance, 12345))
+      obj = described_class.new(api, response_with_job(raw_instance, "/api/v1/jobs/2710/"))
       allow(api).to receive(:get).and_return(instance_double("Faraday::Result", :body => {}.to_json))
 
       expect(obj.job).to be_a AnsibleTowerClient::Job
+    end
+
+    it "returns nil when it is a inventory sync" do
+      obj = described_class.new(api, response_with_job(raw_instance, "/api/v1/inventory_updates/2710/"))
+      allow(api).to receive(:get).and_return(instance_double("Faraday::Result", :body => {}.to_json))
+
+      expect(obj.job).to be_nil
     end
   end
 end


### PR DESCRIPTION
Add logic to filter out workflow job node that is for inventory sync or project sync.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1698837
