### PR TITLE
[WIP] Add upper bounds to faraday versions

### DIFF
--- a/ansible_tower_client.gemspec
+++ b/ansible_tower_client.gemspec
@@ -16,9 +16,9 @@ Gem::Specification.new do |spec|
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
 
-  spec.add_runtime_dependency "activesupport"
-  spec.add_runtime_dependency "faraday"
-  spec.add_runtime_dependency "faraday_middleware"
+  spec.add_runtime_dependency "activesupport", "~> 5.1.7"
+  spec.add_runtime_dependency "faraday", "~> 1.0"
+  spec.add_runtime_dependency "faraday_middleware", "< 1.0.0"
   spec.add_runtime_dependency "more_core_extensions", "~> 3.0"
 
   spec.add_development_dependency "factory_bot", "~> 4.11"


### PR DESCRIPTION
It feels like we maybe might want something like this? 🤷‍♀ 

But we're waiting on them to cut a new middleware gem:
v0.14 is `'faraday', ['>= 0.7.4', '< 1.0']` and won't work 