### PR TITLE
Allow request options to be passed to Faraday so that open_timeout can be set

### DIFF
--- a/lib/ansible_tower_client/connection.rb
+++ b/lib/ansible_tower_client/connection.rb
@@ -20,6 +20,7 @@ module AnsibleTowerClient
       connection_opts = { :ssl => {:verify => verify_ssl} }
       connection_opts[:proxy] = options[:proxy] if options[:proxy].present?
       connection_opts[:headers] = options[:headers] if options[:headers].present?
+      connection_opts[:request] = options[:request] if options[:request].present?
 
       @connection = Faraday.new(options[:base_url], connection_opts) do |f|
         f.use(FaradayMiddleware::EncodeJson)


### PR DESCRIPTION
Accept request options to be sent to faraday so that things like open_timeout can be given.