### PR TITLE
Fix specs with VCRs recorded on previous versions

### DIFF
--- a/lib/ansible_tower_client/api.rb
+++ b/lib/ansible_tower_client/api.rb
@@ -12,7 +12,7 @@ module AnsibleTowerClient
     end
 
     def config
-      JSON.parse(get("config").body)
+      JSON.parse(get("config/").body)
     end
 
     def version


### PR DESCRIPTION
Previous versions of this gem requested /config/ to avoid redundant redirects (added in https://github.com/ansible/ansible_tower_client_ruby/pull/124).  Now it is requesting /config which is causing vcr breakages after https://github.com/ansible/ansible_tower_client_ruby/pull/137 changed [this](https://github.com/ansible/ansible_tower_client_ruby/pull/137/files#diff-6dc31f2bbd85dcda6dd9f0d93fa6e045R15)

Failure on manageiq hammer on first run after v0.21.0 was released https://travis-ci.org/ManageIQ/manageiq/builds/651202354#L1149