### PR TITLE
This never worked as intended, it was evaluated at build time.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,3 @@ require File.join(Bundler::Plugin.index.load_paths("bundler-inject")[0], "bundle
 
 # Specify your gem's dependencies in ansible_tower_client.gemspec
 gemspec
-
-# HACK: Rails 5 dropped support for Ruby < 2.2.2
-active_support_version = "< 5" if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.2.2")
-gem "activesupport", active_support_version


### PR DESCRIPTION
Removing since we're no longer concerned about Ruby < 2.2.2