### PR TITLE
bump more core extensions

### DIFF
--- a/ansible_tower_client.gemspec
+++ b/ansible_tower_client.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "activesupport"
   spec.add_runtime_dependency "faraday"
   spec.add_runtime_dependency "faraday_middleware"
-  spec.add_runtime_dependency "more_core_extensions", "~> 3.0"
+  spec.add_runtime_dependency "more_core_extensions", "~> 4.0"
 
   spec.add_development_dependency "factory_bot", "~> 4.11"
   spec.add_development_dependency "rake", "~> 12.3"


### PR DESCRIPTION


more core extensions is now on 4.1.0 and I was wondering if we might be able to update. 

no particular reason, just update for update's sake

here's what's included:

https://github.com/ManageIQ/more_core_extensions/compare/179bf40..e5b4501
 - Added Ruby 2.7 support [[#79](https://github.com/ManageIQ/more_core_extensions/pull/79)]
 - Added Process#pause, Process#resume, and Process#alive? [[#73](https://github.com/ManageIQ/more_core_extensions/pull/73)]

array added * `#compact_map` - Collect non-nil results from the block
array added `#tabular_sort` - Sorts an Array of Hashes by specific columns

hierarchy added `#descendant_get` - Returns the descendant with a given name

the two breaking changes:
- **BREAKING**: Moved Object#descendant_get to Class#descendant_get [[#75](https://github.com/ManageIQ/more_core_extensions/pull/75)]
- **BREAKING**: Removed deprecated Enumerable#stable_sort_by [[#76](https://github.com/ManageIQ/more_core_extensions/pull/76)]

a minor header output change was made that hasn't been released yet to make tableize more markdown compliant

see https://github.com/ManageIQ/linux_admin/pull/221