### PR TITLE
[WIP] Improve handling of nested workflow_jobs

### DIFF
--- a/lib/ansible_tower_client/base_models/workflow_job_node.rb
+++ b/lib/ansible_tower_client/base_models/workflow_job_node.rb
@@ -5,14 +5,20 @@ module AnsibleTowerClient
     end
 
     def job
-      api.jobs.find(job_id) if job?
+      return unless job?
+
+      if related.job.include?("/jobs/")
+        api.jobs.find(job_id)
+      elsif related.job.include?("/workflow_jobs/")
+        api.workflow_jobs.find(job_id)
+      end
     end
 
     # to filter out WorkflowJobNode that is inventory sync or project sync
     def job?
       return false if !respond_to?(:job_id) || job_id.nil?
 
-      related.job.match?(/jobs/)
+      related.job.match?(/\/(jobs|workflow_jobs)\//)
     end
   end
 end

--- a/spec/workflow_job_node_spec.rb
+++ b/spec/workflow_job_node_spec.rb
@@ -40,6 +40,13 @@ describe AnsibleTowerClient::WorkflowJobNode do
       expect(obj.job).to be_a AnsibleTowerClient::Job
     end
 
+    it "returns a WorkflowJob when the job_id has a workflow_job" do
+      obj = described_class.new(api, response_with_job(raw_instance, "/api/v1/workflow_jobs/2710/"))
+      allow(api).to receive(:get).and_return(instance_double("Faraday::Result", :body => {}.to_json))
+
+      expect(obj.job).to be_a AnsibleTowerClient::WorkflowJob
+    end
+
     it "returns nil when it is a inventory sync" do
       obj = described_class.new(api, response_with_job(raw_instance, "/api/v1/inventory_updates/2710/"))
       allow(api).to receive(:get).and_return(instance_double("Faraday::Result", :body => {}.to_json))


### PR DESCRIPTION
Improve the handling of nested workflow_jobs in the WorkflowJobNode class.

The `#job` method was using `.match?(/jobs/)` to check if it was a job, the problem is that was matching on `/api/v2/workflow_jobs/:id` as well causing `api.jobs.find(job_id)` to fail with a 404.

Fix for the issue noted here: https://github.com/ManageIQ/manageiq-providers-ansible_tower/pull/262#issuecomment-853317690

TODO:
- [x] Add spec tests for `#workflow_job`